### PR TITLE
Fixes for Archived Chats link, silhouette icon incorrectly used in new group topics

### DIFF
--- a/TinodeSDK/Topic.swift
+++ b/TinodeSDK/Topic.swift
@@ -1384,6 +1384,7 @@ public class FndTopic<SP: Codable>: Topic<String, String, SP, Array<String>> {
     init(tinode: Tinode?) {
         super.init(tinode: tinode, name: Tinode.kTopicFnd)
     }
+
     @discardableResult
     override public func setMeta(meta: MsgSetMeta<String, String>) -> PromisedReply<ServerMessage>? {
         if self.subs != nil {
@@ -1394,6 +1395,7 @@ public class FndTopic<SP: Codable>: Topic<String, String, SP, Array<String>> {
         }
         return super.setMeta(meta: meta)
     }
+
     override func routeMetaSub(meta: MsgServerMeta) {
         if let subscriptions = meta.sub {
             for upd in subscriptions {
@@ -1409,8 +1411,8 @@ public class FndTopic<SP: Codable>: Topic<String, String, SP, Array<String>> {
         }
         self.listener?.onSubsUpdated()
     }
+
     override public func getSubscriptions() -> [Subscription<SP, Array<String>>]? {
-        //return mSubs != null ? mSubs.values() : null;
         guard let v = subs?.values else { return nil }
         return Array(v)
     }

--- a/TinodeSDK/Topic.swift
+++ b/TinodeSDK/Topic.swift
@@ -1414,6 +1414,15 @@ public class FndTopic<SP: Codable>: Topic<String, String, SP, Array<String>> {
         guard let v = subs?.values else { return nil }
         return Array(v)
     }
+
+    override func addSubToCache(sub: Subscription<SP, [String]>) {
+        guard let unique = sub.user ?? sub.topic else { return }
+
+        if subs == nil {
+            subs = [:]
+        }
+        subs![unique] = sub
+    }
 }
 
 public class ComTopic<DP: Codable>: Topic<DP, PrivateType, DP, PrivateType> {

--- a/Tinodios/Base.lproj/Main.storyboard
+++ b/Tinodios/Base.lproj/Main.storyboard
@@ -674,14 +674,6 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <view key="tableFooterView" contentMode="scaleToFill" id="5vl-f8-ZTQ" userLabel="Footer to hide separators for empty rows">
-                            <rect key="frame" x="0.0" y="0.0" width="375" height="0.0"/>
-                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
-                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            <accessibility key="accessibilityConfiguration" label="Footer">
-                                <accessibilityTraits key="traits" notEnabled="YES"/>
-                            </accessibility>
-                        </view>
                         <connections>
                             <outlet property="dataSource" destination="n9d-hv-55K" id="oZ5-gs-f1y"/>
                             <outlet property="delegate" destination="n9d-hv-55K" id="db6-Zu-Bbz"/>

--- a/Tinodios/FindInteractor.swift
+++ b/Tinodios/FindInteractor.swift
@@ -80,7 +80,9 @@ class FindInteractor: FindBusinessLogic {
         }
         self.presenter?.presentRemoteContacts(contacts: self.remoteContacts!)
     }
+
     func loadAndPresentContacts(searchQuery: String? = nil) {
+        let changed = self.searchQuery != searchQuery
         self.searchQuery = searchQuery
         queue.async {
             if self.localContacts == nil {
@@ -97,9 +99,9 @@ class FindInteractor: FindBusinessLogic {
                         return r.contains(displayName.startIndex)
                     } :
                     self.localContacts!
-            self.fndTopic?.setMeta(
-                meta: MsgSetMeta(desc: MetaSetDesc(pub: searchQuery != nil ? searchQuery! : Tinode.kNullValue, priv: nil),
-                                 sub: nil, tags: nil))
+            if changed {
+                self.fndTopic?.setMeta(meta: MsgSetMeta(desc: MetaSetDesc(pub: searchQuery != nil ? searchQuery! : Tinode.kNullValue, priv: nil), sub: nil, tags: nil))
+            }
             self.remoteContacts?.removeAll()
             if let queryString = searchQuery, queryString.count >= UiUtils.kMinTagLength {
                 self.fndTopic?.getMeta(query: MsgGetMeta.sub())

--- a/Tinodios/FindViewController.swift
+++ b/Tinodios/FindViewController.swift
@@ -222,6 +222,7 @@ extension FindViewController: ContactViewCellDelegate {
     func selected(from cell: UITableViewCell) {
         guard let indexPath = tableView.indexPathForSelectedRow else { return }
         guard let id = getUniqueId(for: indexPath) else { return }
+
         // If the search bar is active, deactivate it.
         if searchController.isActive {
             // Disable the animation as we are going straight to another view

--- a/Tinodios/NewGroupViewController.swift
+++ b/Tinodios/NewGroupViewController.swift
@@ -25,6 +25,8 @@ class NewGroupViewController: UIViewController, UITableViewDataSource {
     private var contacts: [ContactHolder] = []
     private var selectedContacts: [IndexPath] = []
 
+    private var imageUploaded: Bool = false
+
     private var interactor: NewGroupBusinessLogic?
 
     private var imagePicker: ImagePicker!
@@ -109,7 +111,7 @@ class NewGroupViewController: UIViewController, UITableViewDataSource {
         }
 
         guard !groupName.isEmpty else { return }
-        let avatar = avatarView.image?.resize(width: CGFloat(Float(UiUtils.kAvatarSize)), height: CGFloat(Float(UiUtils.kAvatarSize)), clip: true)
+        let avatar = imageUploaded ? avatarView.image?.resize(width: CGFloat(Float(UiUtils.kAvatarSize)), height: CGFloat(Float(UiUtils.kAvatarSize)), clip: true) : nil
         let tagsList = Utils.parseTags(from: tags)
         self.interactor?.createGroupTopic(titled: groupName, subtitled: privateInfo, with: tagsList, consistingOf: members, withAvatar: avatar)
     }
@@ -193,5 +195,6 @@ extension NewGroupViewController : UICollectionViewDataSource {
 extension NewGroupViewController: ImagePickerDelegate {
     func didSelect(image: UIImage?) {
         self.avatarView.image = image
+        imageUploaded = image != nil
     }
 }

--- a/Tinodios/RegisterViewController.swift
+++ b/Tinodios/RegisterViewController.swift
@@ -20,6 +20,7 @@ class RegisterViewController: UIViewController {
     @IBOutlet weak var avatarView: RoundImageView!
 
     var imagePicker: ImagePicker!
+    var uploadedAvatar: Bool = false
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -67,7 +68,7 @@ class RegisterViewController: UIViewController {
         signUpBtn.isUserInteractionEnabled = false
         let tinode = Cache.getTinode()
 
-        let avatar = avatarView?.image?.resize(width: 128, height: 128, clip: true)
+        let avatar = uploadedAvatar ? avatarView?.image?.resize(width: 128, height: 128, clip: true) : nil
         let vcard = VCard(fn: name, avatar: avatar)
 
         let desc = MetaSetDesc<VCard, String>(pub: vcard, priv: nil)
@@ -131,5 +132,6 @@ class RegisterViewController: UIViewController {
 extension RegisterViewController: ImagePickerDelegate {
     func didSelect(image: UIImage?) {
         self.avatarView.image = image
+        uploadedAvatar = image != nil
     }
 }

--- a/Tinodios/TopicInfoViewController.swift
+++ b/Tinodios/TopicInfoViewController.swift
@@ -471,10 +471,9 @@ extension TopicInfoViewController {
         let uid = sub.user
         let isMe = self.tinode.isMe(uid: uid)
         let pub = sub.pub
-        let displayName = isMe ? "You" : (pub?.fn ?? "Unknown")
 
-        cell.avatar.set(icon: pub?.photo?.image(), title: displayName, id: uid)
-        cell.title.text = displayName
+        cell.avatar.set(icon: pub?.photo?.image(), title: pub?.fn, id: uid)
+        cell.title.text = isMe ? "You" : (pub?.fn ?? "Unknown")
         cell.title.sizeToFit()
         cell.subtitle.text = sub.acs?.givenString
         for l in cell.statusLabels {

--- a/Tinodios/UiUtils.swift
+++ b/Tinodios/UiUtils.swift
@@ -279,6 +279,10 @@ extension UIViewController {
                 // Descend to the chat list controller in the navigation stack.
                 while navController.topViewController?.restorationIdentifier != "ChatListViewController" {
                     let v = navController.popViewController(animated: false)
+                    if v == nil {
+                        // FIXME: DEBUGGING ONLY. Otherwise an endless loop happens.
+                        break
+                    }
                     v?.dismiss(animated: false, completion: nil)
                 }
                 let messageVC = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "MessageViewController") as! MessageViewController


### PR DESCRIPTION
* Archived Chats link converted from a table cell to a footer.
* Placeholder silhouette icon was incorrectly used as a new group topic avatar & new user avatar when no avatar image was uploaded.
* In group topic member list current user's avatar would show (Y) (from You) instead of the first letter of the name.
* Group topics were not added to subscriptions cache in FndTopic