### PR TITLE
Bug fixes

### DIFF
--- a/TinodeSDK/Tinode.swift
+++ b/TinodeSDK/Tinode.swift
@@ -484,7 +484,7 @@ public class Tinode {
                             lang: kLocale))
         return try! sendWithPromise(payload: msg, with: msgId).thenApply(
             onSuccess: { [weak self] pkt in
-                guard let pkt = pkt, let ctrl = pkt.ctrl else {
+                guard let ctrl = pkt?.ctrl else {
                     throw TinodeError.invalidReply("Unexpected type of reply packet to hello")
                 }
                 if !(ctrl.params?.isEmpty ?? true) {
@@ -833,7 +833,7 @@ public class Tinode {
                     if let connected = tinode.connectedPromise, !connected.isDone {
                         try connected.resolve(result: pkt)
                     }
-                    if let pkt = pkt, let ctrl = pkt.ctrl {
+                    if let let ctrl = pkt?.ctrl {
                         tinode.timeAdjustment = Date().timeIntervalSince(ctrl.ts)
                         // tinode store
                         tinode.store?.setTimeAdjustment(adjustment: tinode.timeAdjustment)

--- a/TinodeSDK/Tinode.swift
+++ b/TinodeSDK/Tinode.swift
@@ -387,8 +387,7 @@ public class Tinode {
                     if ctrl.code >= 200 && ctrl.code < 400 {
                         try r.resolve(result: serverMsg)
                     } else {
-                        try r.reject(error: TinodeError.serverResponseError(
-                            ctrl.code, ctrl.text, ctrl.getStringParam(for: "what")))
+                        try r.reject(error: TinodeError.serverResponseError(ctrl.code, ctrl.text, ctrl.getStringParam(for: "what")))
                     }
                 }
                 Tinode.log.debug("ctrl.id = %d", id)
@@ -485,7 +484,7 @@ public class Tinode {
                             lang: kLocale))
         return try! sendWithPromise(payload: msg, with: msgId).thenApply(
             onSuccess: { [weak self] pkt in
-                guard let ctrl = pkt.ctrl else {
+                guard let pkt = pkt, let ctrl = pkt.ctrl else {
                     throw TinodeError.invalidReply("Unexpected type of reply packet to hello")
                 }
                 if !(ctrl.params?.isEmpty ?? true) {
@@ -668,7 +667,7 @@ public class Tinode {
         }
         return try! future.then(
             onSuccess: { [weak self] pkt in
-                try self?.loginSuccessful(ctrl: pkt.ctrl)
+                try self?.loginSuccessful(ctrl: pkt?.ctrl)
                 return nil
             }, onFailure: { [weak self] err in
                 if let e = err as? TinodeError {
@@ -738,7 +737,7 @@ public class Tinode {
         return try! sendWithPromise(payload: msg, with: msgId).then(
             onSuccess: { [weak self] pkt in
                 self?.loginInProgress = false
-                try self?.loginSuccessful(ctrl: pkt.ctrl)
+                try self?.loginSuccessful(ctrl: pkt?.ctrl)
                 return nil
             },
             onFailure: { [weak self] err in
@@ -834,13 +833,13 @@ public class Tinode {
                     if let connected = tinode.connectedPromise, !connected.isDone {
                         try connected.resolve(result: pkt)
                     }
-                    let ctrl = pkt.ctrl!
-                    tinode.timeAdjustment = Date().timeIntervalSince(ctrl.ts)
-                    // tinode store
-                    tinode.store?.setTimeAdjustment(adjustment: tinode.timeAdjustment)
-                    // listener
-                    tinode.listener?.onConnect(
-                        code: ctrl.code, reason: ctrl.text, params: ctrl.params)
+                    if let pkt = pkt, let ctrl = pkt.ctrl {
+                        tinode.timeAdjustment = Date().timeIntervalSince(ctrl.ts)
+                        // tinode store
+                        tinode.store?.setTimeAdjustment(adjustment: tinode.timeAdjustment)
+                        // listener
+                        tinode.listener?.onConnect(code: ctrl.code, reason: ctrl.text, params: ctrl.params)
+                    }
                     return nil
                 }, onFailure: nil)
                 if tinode.autoLogin && reconnecting {

--- a/TinodeSDK/Topic.swift
+++ b/TinodeSDK/Topic.swift
@@ -530,7 +530,7 @@ open class Topic<DP: Codable, DR: Codable, SP: Codable, SR: Codable>: TopicProto
                 let isAttached = self?.attached ?? false
                 if !isAttached {
                     self?.attached = true
-                    if let ctrl = msg.ctrl {
+                    if let msg = msg, let ctrl = msg.ctrl {
                         if !(ctrl.params?.isEmpty ?? false) {
                             self?.description?.acs = Acs(from: ctrl.getStringDict(for: "acs"))
                             if self?.isNew ?? false {
@@ -789,7 +789,7 @@ open class Topic<DP: Codable, DR: Codable, SP: Codable, SR: Codable>: TopicProto
         // Delete works even if the topic is not attached.
         return try! tinode!.delTopic(topicName: name)?.then(
             onSuccess: { msg in
-                self.topicLeft(unsub: true, code: msg.ctrl?.code, reason: msg.ctrl?.text)
+                self.topicLeft(unsub: true, code: msg?.ctrl?.code, reason: msg?.ctrl?.text)
                 self.tinode!.stopTrackingTopic(topicName: self.name)
                 self.persist(false)
                 return nil
@@ -877,8 +877,8 @@ open class Topic<DP: Codable, DR: Codable, SP: Codable, SR: Codable>: TopicProto
         do {
             return try tinode?.setMeta(for: self.name, meta: meta)?.thenApply(
                 onSuccess: { msg in
-                    print("setMeta thenApply -> ctrl: \(msg.ctrl)")
-                    if let ctrl = msg.ctrl {
+                    print("setMeta thenApply -> ctrl: \(msg?.ctrl)")
+                    if let ctrl = msg?.ctrl {
                         self.update(ctrl: ctrl, meta: meta)
                     }
                     return nil
@@ -1069,7 +1069,7 @@ open class Topic<DP: Codable, DR: Codable, SP: Codable, SR: Codable>: TopicProto
                         guard let s = self else {
                             throw TinodeError.invalidState("Topic.self not available in result handler")
                         }
-                        s.topicLeft(unsub: unsub, code: msg.ctrl?.code, reason: msg.ctrl?.text)
+                        s.topicLeft(unsub: unsub, code: msg?.ctrl?.code, reason: msg?.ctrl?.text)
                         if unsub ?? false {
                             s.tinode?.stopTrackingTopic(topicName: s.name)
                             s.persist(false)
@@ -1110,7 +1110,7 @@ open class Topic<DP: Codable, DR: Codable, SP: Codable, SR: Codable>: TopicProto
     public func publish(content: Drafty, msgId: Int64) -> PromisedReply<ServerMessage>? {
         return try! tinode!.publish(topic: name, data: content)?.then(
             onSuccess: { [weak self] msg in
-                self?.processDelivery(ctrl: msg.ctrl, id: msgId)
+                self?.processDelivery(ctrl: msg?.ctrl, id: msgId)
                 return nil
             }, onFailure: { [weak self] err in
                 self?.store?.msgSyncing(topic: self!, dbMessageId: msgId, sync: false)
@@ -1140,9 +1140,8 @@ open class Topic<DP: Codable, DR: Codable, SP: Codable, SR: Codable>: TopicProto
             return try! self.tinode?.delMessage(
                 topicName: self.name, list: pendingDeletes, hard: hard)?.then(
                     onSuccess: { [weak self] msg in
-                        if let id = msg.ctrl?.getIntParam(for: "del"), let s = self {
-                            _ = s.store?.msgDelete(
-                                topic: s, delete: id, deleteAll: pendingDeletes)
+                        if let id = msg?.ctrl?.getIntParam(for: "del"), let s = self {
+                            _ = s.store?.msgDelete(topic: s, delete: id, deleteAll: pendingDeletes)
                         }
                         return nil
                     }, onFailure: nil)
@@ -1156,7 +1155,7 @@ open class Topic<DP: Codable, DR: Codable, SP: Codable, SR: Codable>: TopicProto
             do {
                 return try tinode?.delMessage(topicName: self.name, fromId: fromId, toId: toId, hard: hard)?.then(
                     onSuccess: { [weak self] msg in
-                        if let delId = msg.ctrl?.getIntParam(for: "del"), delId > 0 {
+                        if let delId = msg?.ctrl?.getIntParam(for: "del"), delId > 0 {
                             self?.store?.msgDelete(topic: self!, delete: delId, deleteFrom: fromId, deleteTo: toId)
                         }
                         return nil

--- a/TinodeSDK/Topic.swift
+++ b/TinodeSDK/Topic.swift
@@ -916,9 +916,9 @@ open class Topic<DP: Codable, DR: Codable, SP: Codable, SR: Codable>: TopicProto
         if description!.acs == nil {
             description!.acs = Acs()
         }
-        let mode = uidIsSelf ? description!.acs!.want : sub!.acs!.given
-        if mode?.update(from: update) ?? false {
-            return setSubscription(sub: MetaSetSub(user: uid, mode: mode?.description))
+        let mode = AcsHelper(ah: uidIsSelf ? description!.acs!.want : sub!.acs!.given)
+        if mode.update(from: update) {
+            return setSubscription(sub: MetaSetSub(user: uid, mode: mode.description))
         }
         return PromisedReply<ServerMessage>(value: ServerMessage())
     }

--- a/TinodeSDK/Topic.swift
+++ b/TinodeSDK/Topic.swift
@@ -530,7 +530,7 @@ open class Topic<DP: Codable, DR: Codable, SP: Codable, SR: Codable>: TopicProto
                 let isAttached = self?.attached ?? false
                 if !isAttached {
                     self?.attached = true
-                    if let msg = msg, let ctrl = msg.ctrl {
+                    if let ctrl = msg?.ctrl {
                         if !(ctrl.params?.isEmpty ?? false) {
                             self?.description?.acs = Acs(from: ctrl.getStringDict(for: "acs"))
                             if self?.isNew ?? false {

--- a/Tinodios/CredentialsViewController.swift
+++ b/Tinodios/CredentialsViewController.swift
@@ -39,8 +39,8 @@ class CredentialsViewController : UIViewController {
         
         do {
             try tinode.loginToken(token: token, creds: creds)?
-                .then(onSuccess: {[weak self] msg in
-                    if let code = msg.ctrl?.code, code >= 300 {
+                .then(onSuccess: { [weak self] msg in
+                    if let ctrl = msg?.ctrl, ctrl.code >= 300 {
                         print("login error")
                     } else {
                         let storyboard = UIStoryboard(name: "Main", bundle: nil)

--- a/Tinodios/MessageCell.swift
+++ b/Tinodios/MessageCell.swift
@@ -191,6 +191,7 @@ class MessageCell: UICollectionViewCell {
     }
 
     override func resignFirstResponder() -> Bool {
+        super.resignFirstResponder()
         return true
     }
 }

--- a/Tinodios/MessageInteractor.swift
+++ b/Tinodios/MessageInteractor.swift
@@ -250,7 +250,7 @@ class MessageInteractor: DefaultComTopic.Listener, MessageBusinessLogic, Message
         } catch TinodeError.notConnected(_) {
             UiUtils.showToast(message: "You are offline")
         } catch {
-            UiUtils.showToast(message: "Action failed: \(error)")
+            UiUtils.showToast(message: "Action failed: \(error.localizedDescription)")
         }
     }
     func acceptInvitation() {
@@ -270,7 +270,7 @@ class MessageInteractor: DefaultComTopic.Listener, MessageBusinessLogic, Message
             } catch TinodeError.notConnected(_) {
                 UiUtils.showToast(message: "You are offline")
             } catch {
-                UiUtils.showToast(message: "Operation failed \(error)")
+                UiUtils.showToast(message: "Operation failed \(error.localizedDescription)")
             }
         }
         _ = try? response?.thenApply(onSuccess: { msg in
@@ -298,7 +298,7 @@ class MessageInteractor: DefaultComTopic.Listener, MessageBusinessLogic, Message
         } catch TinodeError.notConnected(_) {
             UiUtils.showToast(message: "You are offline")
         } catch {
-            UiUtils.showToast(message: "Operation failed \(error)")
+            UiUtils.showToast(message: "Operation failed \(error.localizedDescription)")
         }
     }
     static private func existingInteractor(for topicName: String?) -> MessageInteractor? {

--- a/Tinodios/MessageInteractor.swift
+++ b/Tinodios/MessageInteractor.swift
@@ -29,6 +29,7 @@ protocol MessageBusinessLogic: class {
 protocol MessageDataStore {
     var topicName: String? { get set }
     var topic: DefaultComTopic? { get set }
+    @discardableResult
     func setup(topicName: String?) -> Bool
     func loadMessages()
     func loadNextPage()
@@ -231,7 +232,7 @@ class MessageInteractor: DefaultComTopic.Listener, MessageBusinessLogic, Message
         } catch TinodeError.notConnected(_) {
             UiUtils.showToast(message: "You are offline")
         } catch {
-            UiUtils.showToast(message: "Action failed: \(error)")
+            UiUtils.showToast(message: "Action failed: \(error.localizedDescription)")
         }
     }
 

--- a/Tinodios/MessageView.swift
+++ b/Tinodios/MessageView.swift
@@ -92,7 +92,7 @@ extension MessageView {
             messageLabel.textColor = .darkGray
             messageLabel.numberOfLines = 0
             messageLabel.textAlignment = .center
-            messageLabel.font = .preferredFont(forTextStyle: .body)
+            messageLabel.font = .preferredFont(forTextStyle: .headline)
             messageLabel.sizeToFit()
 
             self.backgroundView = messageLabel

--- a/Tinodios/RegisterViewController.swift
+++ b/Tinodios/RegisterViewController.swift
@@ -89,10 +89,9 @@ class RegisterViewController: UIViewController {
 
             try future?.then(
                 onSuccess: { [weak self] msg in
-                    if let code = msg.ctrl?.code, code >= 300 {
-                        let vc = self?.storyboard?.instantiateViewController(withIdentifier: String(describing: type(of: CredentialsViewController())))
-                            as! CredentialsViewController
-                        if let cArr = msg.ctrl!.getStringArray(for: "cred") {
+                    if let ctrl = msg?.ctrl, ctrl.code >= 300 {
+                        let vc = self?.storyboard?.instantiateViewController(withIdentifier: String(describing: type(of: CredentialsViewController()))) as! CredentialsViewController
+                        if let cArr = ctrl.getStringArray(for: "cred") {
                             for c in cArr {
                                 vc.meth = c
                             }

--- a/Tinodios/TopicInfoViewController.swift
+++ b/Tinodios/TopicInfoViewController.swift
@@ -337,7 +337,7 @@ class TopicInfoViewController: UITableViewController {
         }
     }
 
-    private func promiseSuccessHandler(msg: ServerMessage) throws -> PromisedReply<ServerMessage>? {
+    private func promiseSuccessHandler(msg: ServerMessage?) throws -> PromisedReply<ServerMessage>? {
         DispatchQueue.main.async { self.reloadData() }
         return nil
     }

--- a/Tinodios/UiUtils.swift
+++ b/Tinodios/UiUtils.swift
@@ -216,8 +216,8 @@ class UiUtils {
         }
         return nil
     }
-    public static func ToastSuccessHandler(msg: ServerMessage) throws -> PromisedReply<ServerMessage>? {
-        if let ctrl = msg.ctrl, ctrl.code >= 300 {
+    public static func ToastSuccessHandler(msg: ServerMessage?) throws -> PromisedReply<ServerMessage>? {
+        if let ctrl = msg?.ctrl, ctrl.code >= 300 {
             DispatchQueue.main.async {
                 UiUtils.showToast(message: "Something went wrong: \(ctrl.code) - \(ctrl.text)", level: .warning)
             }
@@ -250,7 +250,7 @@ class UiUtils {
             }
             return try reply?.then(
                 onSuccess: { msg in
-                    if let ctrl = msg.ctrl, ctrl.code >= 300 {
+                    if let ctrl = msg?.ctrl, ctrl.code >= 300 {
                         DispatchQueue.main.async {
                             UiUtils.showToast(message: "Couldn't update permissions: \(ctrl.text) (\(ctrl.code))", level: .warning)
                         }

--- a/Tinodios/UiUtils.swift
+++ b/Tinodios/UiUtils.swift
@@ -252,14 +252,14 @@ class UiUtils {
                 onSuccess: { msg in
                     if let ctrl = msg.ctrl, ctrl.code >= 300 {
                         DispatchQueue.main.async {
-                            UiUtils.showToast(message: "Couldn't update permissions: \(ctrl.code) - \(ctrl.text)", level: .warning)
+                            UiUtils.showToast(message: "Couldn't update permissions: \(ctrl.text) (\(ctrl.code))", level: .warning)
                         }
                     }
                     return nil
                 },
                 onFailure: { err in
                     DispatchQueue.main.async {
-                        UiUtils.showToast(message: "Error changing permissions \(err)")
+                        UiUtils.showToast(message: "Error changing permissions \(err.localizedDescription)")
                     }
                     return nil
                 })

--- a/Tinodios/Utils.swift
+++ b/Tinodios/Utils.swift
@@ -67,7 +67,7 @@ class Utils {
             } else if n == new.count || old[o].seqId < new[n].seqId {
                 // Present in old, missing in new: removed
                 removed.append(o)
-                if mutated.last ?? -1 != n {
+                if mutated.last ?? -1 != n && n < new.count {
                     // Appending n, not o because mutated is an index agaist the new data.
                     mutated.append(n)
                 }

--- a/Tinodios/account/ContactsSynchronizer.swift
+++ b/Tinodios/account/ContactsSynchronizer.swift
@@ -153,7 +153,7 @@ class ContactsSynchronizer {
                     if try future.waitResult() {
                         print("okay")
                         let pkt = try! future.getResult()
-                        guard let subs = pkt.meta?.sub else { return }
+                        guard let subs = pkt?.meta?.sub else { return }
                         print("got subs\nquery = \(contacts)\nsubs = \(subs)")
                         for sub in subs {
                             if Tinode.topicTypeByName(name: sub.user) == .p2p {


### PR DESCRIPTION
* Promises refactored a bit to correctly handle the case of `promise.thenCatch(...).thenApply(...)`: if `onFailure` returns `nil`, call the subsequent `thenApply` with a `nil` argument instead of throwing `PromisedReplyError.illegalStateError("called handleSuccess on a non-resolved promise")`.
* Work around for an apple bug when deleting the last message in a conversation.
* Bug fix for access mode being changed even if the server rejects the change.