### PR TITLE
Fixes for missing login and layout

### DIFF
--- a/Tinodios/CredentialsViewController.swift
+++ b/Tinodios/CredentialsViewController.swift
@@ -64,6 +64,9 @@ class CredentialsViewController : UIViewController {
                             UiUtils.showToast(message: "Verification failure: \(ctrl.code) \(ctrl.text)")
                         }
                     } else {
+                        if let token = tinode.authToken {
+                            tinode.setAutoLoginWithToken(token: token)
+                        }
                         UiUtils.routeToChatListVC()
                     }
                     return nil

--- a/Tinodios/MessageViewController.swift
+++ b/Tinodios/MessageViewController.swift
@@ -964,7 +964,16 @@ extension MessageViewController : MessageViewLayoutDelegate {
             attributedText.append(NSAttributedString(string: "none", attributes: [.font: Constants.kContentFont]))
         }
         attributedText.append(NSAttributedString(string: carveout, attributes: [.font: Constants.kContentFont]))
-        let size = attributedText.boundingRect(with: CGSize(width: maxWidth, height: .greatestFiniteMagnitude), options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil).integral.size
+
+        // Calculate content size.
+        // Per https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/TextLayout/Tasks/StringHeight.html
+        let ts = NSTextStorage(attributedString: attributedText)
+        let tc = NSTextContainer(size: CGSize(width: maxWidth, height: .greatestFiniteMagnitude))
+        let lm = NSLayoutManager()
+        lm.addTextContainer(tc)
+        ts.addLayoutManager(lm)
+
+        let size = lm.usedRect(for: tc).integral.size
         return size
     }
 }

--- a/Tinodios/MessageViewController.swift
+++ b/Tinodios/MessageViewController.swift
@@ -150,6 +150,8 @@ class MessageViewController: UIViewController {
 
     var isInitialLayout = true
 
+    private var textSizeHelper = TextSizeHelper()
+
     // MARK: initializers
 
     init() {
@@ -965,16 +967,7 @@ extension MessageViewController : MessageViewLayoutDelegate {
         }
         attributedText.append(NSAttributedString(string: carveout, attributes: [.font: Constants.kContentFont]))
 
-        // Calculate content size.
-        // Per https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/TextLayout/Tasks/StringHeight.html
-        let ts = NSTextStorage(attributedString: attributedText)
-        let tc = NSTextContainer(size: CGSize(width: maxWidth, height: .greatestFiniteMagnitude))
-        let lm = NSLayoutManager()
-        lm.addTextContainer(tc)
-        ts.addLayoutManager(lm)
-
-        let size = lm.usedRect(for: tc).integral.size
-        return size
+        return textSizeHelper.computeSize(for: attributedText, within: maxWidth)
     }
 }
 

--- a/Tinodios/ResetPasswordViewController.swift
+++ b/Tinodios/ResetPasswordViewController.swift
@@ -65,6 +65,13 @@ class ResetPasswordViewController : UIViewController {
                 .thenApply(onSuccess: { _ in
                     return tinode.requestResetPassword(method: credential.methodName(), newValue: normalized)
                 })?
+                .thenApply(onSuccess: { _ in
+                    DispatchQueue.main.async { UiUtils.showToast(message: "Message with instructions sent to the provided address.") }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1)) { [weak self] in
+                        self?.navigationController?.popViewController(animated: true)
+                    }
+                    return nil
+                })?
                 .thenCatch(onFailure: UiUtils.ToastFailureHandler)?
                 .thenFinally {
                     UiUtils.toggleProgressOverlay(in: self, visible: false)

--- a/Tinodios/SignupViewController.swift
+++ b/Tinodios/SignupViewController.swift
@@ -93,6 +93,9 @@ class SignupViewController: UITableViewController {
                                                          verifying: ctrl.getStringArray(for: "cred")?.first)
                         }
                     } else {
+                        if let token = tinode.authToken {
+                            tinode.setAutoLoginWithToken(token: token)
+                        }
                         UiUtils.routeToChatListVC()
                     }
                     return nil

--- a/Tinodios/UiUtils.swift
+++ b/Tinodios/UiUtils.swift
@@ -37,6 +37,31 @@ class UiTinodeEventListener : TinodeEventListener {
     func onPresMessage(pres: MsgServerPres?) {}
 }
 
+// Calculates attributed string size (bounding rectangle) with with specified width.
+// Can't use AttributedString.boundingRect(with CGSize) per
+// https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/TextLayout/Tasks/StringHeight.html
+class TextSizeHelper {
+    private let textStorage: NSTextStorage
+    private let textContainer: NSTextContainer
+    private let layoutManager: NSLayoutManager
+
+    init() {
+        textStorage = NSTextStorage()
+        textContainer = NSTextContainer()
+        layoutManager = NSLayoutManager()
+
+        layoutManager.addTextContainer(textContainer)
+        textStorage.addLayoutManager(layoutManager)
+    }
+
+    public func computeSize(for attributedText: NSAttributedString,
+                            within maxWidth: CGFloat) -> CGSize {
+        textStorage.setAttributedString(attributedText)
+        textContainer.size = CGSize(width: maxWidth, height: .greatestFiniteMagnitude)
+        return layoutManager.usedRect(for: textContainer).integral.size
+    }
+}
+
 enum ToastLevel {
     case error, warning, info
 }


### PR DESCRIPTION
Set auto login in SignupVC and CredentialsVC.
Fix message height calculation in MessageVC.
Route back to login screen in reset password VC.