### PR TITLE
Fix for broken image picker

### DIFF
--- a/TinodeSDK/Topic.swift
+++ b/TinodeSDK/Topic.swift
@@ -1225,6 +1225,13 @@ open class MeTopic<DP: Codable & Mergeable>: Topic<DP, PrivateType, DP, PrivateT
             super.routePres(pres: pres)
             return
         }
+
+        if what == .kUpd && Tinode.kTopicMe == pres.src {
+            // Me's desc was updated, fetch the updated version.
+            getMeta(query: getMetaGetBuilder().withDesc().build())
+            return
+        }
+
         // "what":"tags" has src == nil
         if let topic = pres.src != nil ? tinode!.getTopic(topicName: pres.src!) : nil {
             switch what {

--- a/Tinodios/AccountSettingsViewController.swift
+++ b/Tinodios/AccountSettingsViewController.swift
@@ -93,7 +93,7 @@ class AccountSettingsViewController: UITableViewController {
             action: #selector(AccountSettingsViewController.termsOfUseClicked),
             actionTarget: self)
 
-        self.imagePicker = ImagePicker(presentationController: self, delegate: self)
+        self.imagePicker = ImagePicker(presentationController: self, delegate: self, editable: true)
 
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
         let versionCode = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"

--- a/Tinodios/Info.plist
+++ b/Tinodios/Info.plist
@@ -31,7 +31,7 @@
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>$(APP_NAME) needs access to your photos to let you you send them to your contacts</string>
 	<key>NSCameraUsageDescription</key>
-	<string>$(APP_NAME) allows you to take pictures with camera and upload these as avatar or messages </string>
+	<string>$(APP_NAME) takes photos with the camera to use as avatar or to send them to your contacts </string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/Tinodios/Info.plist
+++ b/Tinodios/Info.plist
@@ -31,7 +31,7 @@
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>$(APP_NAME) needs access to your photos to let you you send them to your contacts</string>
 	<key>NSCameraUsageDescription</key>
-	<string>$(APP_NAME) takes photos with the camera to use as avatar or to send them to your contacts </string>
+	<string>$(APP_NAME) takes photos with the camera to use as avatar or to send them to your contacts</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/Tinodios/MessageViewController+SendMessageBarDelegate.swift
+++ b/Tinodios/MessageViewController+SendMessageBarDelegate.swift
@@ -82,7 +82,7 @@ extension MessageViewController : ImagePickerDelegate {
         let mimeType: String = mime == "image/png" ?  mime! : "image/jpeg"
 
         // Ensure image size in bytes and liner dimensions are under the limits.
-        guard let image = image?.resize(byteSize: MessageViewController.kMaxInbandAttachmentSize, asMimeType: mimeType)?.resize(width: UiUtils.kMaxBitmapSize, height: UiUtils.kMaxBitmapSize, clip: false) else { return }
+        guard let image = image?.resize(width: UiUtils.kMaxBitmapSize, height: UiUtils.kMaxBitmapSize, clip: false)?.resize(byteSize: MessageViewController.kMaxInbandAttachmentSize, asMimeType: mimeType) else { return }
 
         guard let bits = image.pixelData(forMimeType: mime) else { return }
 

--- a/Tinodios/MessageViewController+SendMessageBarDelegate.swift
+++ b/Tinodios/MessageViewController+SendMessageBarDelegate.swift
@@ -81,7 +81,7 @@ extension MessageViewController : ImagePickerDelegate {
     func didSelect(image: UIImage?, mimeType mime: String?, fileName fname: String?) {
         let mimeType: String = mime == "image/png" ?  mime! : "image/jpeg"
 
-        // Ensure image size in bytes and liner dimensions are under the limits.
+        // Ensure image size in bytes and linear dimensions are under the limits.
         guard let image = image?.resize(width: UiUtils.kMaxBitmapSize, height: UiUtils.kMaxBitmapSize, clip: false)?.resize(byteSize: MessageViewController.kMaxInbandAttachmentSize, asMimeType: mimeType) else { return }
 
         guard let bits = image.pixelData(forMimeType: mime) else { return }

--- a/Tinodios/MessageViewController.swift
+++ b/Tinodios/MessageViewController.swift
@@ -196,7 +196,7 @@ class MessageViewController: UIViewController {
 
     private func setup() {
         myUID = Cache.getTinode().myUid
-        self.imagePicker = ImagePicker(presentationController: self, delegate: self)
+        self.imagePicker = ImagePicker(presentationController: self, delegate: self, editable: false)
 
         let interactor = MessageInteractor()
         let presenter = MessagePresenter()

--- a/Tinodios/NewGroupViewController.swift
+++ b/Tinodios/NewGroupViewController.swift
@@ -32,7 +32,7 @@ class NewGroupViewController: UITableViewController {
     private var imagePicker: ImagePicker!
 
     private func setup() {
-        self.imagePicker = ImagePicker(presentationController: self, delegate: self)
+        self.imagePicker = ImagePicker(presentationController: self, delegate: self, editable: true)
         self.tagsTextField.onVerifyTag = { (_, tag) in
             return Utils.isValidTag(tag: tag)
         }

--- a/Tinodios/SignupViewController.swift
+++ b/Tinodios/SignupViewController.swift
@@ -23,7 +23,7 @@ class SignupViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        self.imagePicker = ImagePicker(presentationController: self, delegate: self)
+        self.imagePicker = ImagePicker(presentationController: self, delegate: self, editable: true)
 
         // Listen to text change events to clear the possible error from earlier attempt.
         loginTextField.addTarget(self, action: #selector(textFieldDidChange(_:)), for: UIControl.Event.editingChanged)

--- a/Tinodios/TopicInfoViewController.swift
+++ b/Tinodios/TopicInfoViewController.swift
@@ -175,7 +175,7 @@ class TopicInfoViewController: UITableViewController {
         }
 
         self.imagePicker = ImagePicker(
-            presentationController: self, delegate: self)
+            presentationController: self, delegate: self, editable: true)
     }
 
     private func reloadData() {

--- a/Tinodios/UiUtils.swift
+++ b/Tinodios/UiUtils.swift
@@ -576,15 +576,15 @@ extension UIImage {
         let originalWidth = CGFloat(self.size.width * self.scale)
         let originalHeight = CGFloat(self.size.height * self.scale)
 
-        // scale is [0,1): 0 - very large original, 1: under the limits already.
+        // scale is [0,1): ~0 - very large original, =1: under the limits already.
         let scaleX = min(originalWidth, maxWidth) / originalWidth
         let scaleY = min(originalHeight, maxHeight) / originalHeight
         // How much to scale the image
         let scale = clip ?
-            // Scale as little as possible: only one dimension is below the limit, clip the other dimension; the image will have the new aspect ratio.
-            min(scaleX, scaleY) :
+            // Scale as little as possible (large 'scale' == little change): only one dimension is below the limit, clip the other dimension; the image will have the new aspect ratio.
+            max(scaleX, scaleY) :
             // Both width and height are below the limits: no clipping will occur, the image will keep the original aspect ratio.
-            max(scaleX, scaleY)
+            min(scaleX, scaleY)
 
         let dstSize = CGSize(width: min(maxWidth, originalWidth * scale), height: min(maxHeight, originalHeight * scale))
 

--- a/Tinodios/UiUtils.swift
+++ b/Tinodios/UiUtils.swift
@@ -290,7 +290,10 @@ class UiUtils {
         parent.addSubview(toastView)
         label.sizeToFit()
 
-        let toastHeight = max(min(label.frame.height + spacing * 3, maxMessageHeight), minMessageHeight)
+        var toastHeight = max(min(label.frame.height + spacing * 3, maxMessageHeight), minMessageHeight)
+        if #available(iOS 11.0, *) {
+            toastHeight += parent.safeAreaInsets.bottom
+        }
         toastView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             toastView.leadingAnchor.constraint(equalTo: parent.leadingAnchor, constant: 0),
@@ -576,12 +579,12 @@ extension UIImage {
         // scale is [0,1): 0 - very large original, 1: under the limits already.
         let scaleX = min(originalWidth, maxWidth) / originalWidth
         let scaleY = min(originalHeight, maxHeight) / originalHeight
+        // How much to scale the image
         let scale = clip ?
-            // How much to scale the image with at least of of either width or height below the limits; clip the other dimension, the image will have the new aspect ratio.
-            max(scaleX, scaleY) :
-            // How much to scale the image that has both width and height below the limits: no clipping will occur,
-            // the image will keep the original aspect ratio.
-            min(scaleX, scaleY)
+            // Scale as little as possible: only one dimension is below the limit, clip the other dimension; the image will have the new aspect ratio.
+            min(scaleX, scaleY) :
+            // Both width and height are below the limits: no clipping will occur, the image will keep the original aspect ratio.
+            max(scaleX, scaleY)
 
         let dstSize = CGSize(width: min(maxWidth, originalWidth * scale), height: min(maxHeight, originalHeight * scale))
 

--- a/Tinodios/widgets/ImagePicker.swift
+++ b/Tinodios/widgets/ImagePicker.swift
@@ -18,7 +18,7 @@ open class ImagePicker: NSObject {
     private weak var presentationController: UIViewController?
     private weak var delegate: ImagePickerDelegate?
 
-    public init(presentationController: UIViewController, delegate: ImagePickerDelegate) {
+    public init(presentationController: UIViewController, delegate: ImagePickerDelegate, editable: Bool) {
         self.pickerController = UIImagePickerController()
 
         super.init()
@@ -27,7 +27,7 @@ open class ImagePicker: NSObject {
         self.delegate = delegate
 
         self.pickerController.delegate = self
-        self.pickerController.allowsEditing = true
+        self.pickerController.allowsEditing = editable
 
         self.pickerController.mediaTypes = [kUTTypeImage as String]
     }
@@ -88,7 +88,7 @@ extension ImagePicker: UIImagePickerControllerDelegate, UINavigationControllerDe
 
     public func imagePickerController(_ picker: UIImagePickerController,
                                       didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
-        guard let image = info[.editedImage] as? UIImage else {
+        guard let image = info[self.pickerController.allowsEditing ? .editedImage : .originalImage] as? UIImage else {
             return self.pickerController(picker, didSelect: nil, mimeType: nil, fileName: nil)
         }
 


### PR DESCRIPTION
I made image picker uneditable. I.e. it just picks and sends an image without any intermediate steps. Apple's editable image picker is forever broken. There is no way to send an original image if it's in portrait orientation. Everybody seemingly follows these steps:
1. Pick an image from camera or roll with allowsEditing = false
2. Uses custom cropper/editor

We will have to build 2.

I also made Toast taller.