### PR TITLE
Keyboard handling fix 

### DIFF
--- a/Tinodios.xcodeproj/project.pbxproj
+++ b/Tinodios.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		B0DF032F2282FF46000F9492 /* SendMessageBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0DF032E2282FF46000F9492 /* SendMessageBar.swift */; };
 		B0DF03312283FFD8000F9492 /* PlaceholderTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0DF03302283FFD8000F9492 /* PlaceholderTextView.swift */; };
 		B0F98C8322E381C300444121 /* MessageMenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F98C8222E381C300444121 /* MessageMenuItem.swift */; };
+		FA37AD24238B0D6F00301261 /* KeyboardInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA37AD23238B0D6F00301261 /* KeyboardInfo.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -201,6 +202,7 @@
 		B0F98C8222E381C300444121 /* MessageMenuItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageMenuItem.swift; sourceTree = "<group>"; };
 		B36DBFFF235D850000724348 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Main.strings"; sourceTree = "<group>"; };
 		B36DC000235D850000724348 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/LaunchScreen.strings"; sourceTree = "<group>"; };
+		FA37AD23238B0D6F00301261 /* KeyboardInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardInfo.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -294,6 +296,7 @@
 				B031BE542263075E004160AE /* Settings.bundle */,
 				0A0380E921B3CCB000A3FA0E /* Supporting Files */,
 				0A0380E321B3CC8200A3FA0E /* Info.plist */,
+				FA37AD23238B0D6F00301261 /* KeyboardInfo.swift */,
 			);
 			path = Tinodios;
 			sourceTree = "<group>";
@@ -644,6 +647,7 @@
 				0A8A8BDA21C380E80090BCBA /* Cache.swift in Sources */,
 				B0DF031D227C604C000F9492 /* MessageCell.swift in Sources */,
 				B0DF0323228051B4000F9492 /* MessageViewController+Keyboard.swift in Sources */,
+				FA37AD24238B0D6F00301261 /* KeyboardInfo.swift in Sources */,
 				0AE50D4822156A5B0021F7B7 /* FindPresenter.swift in Sources */,
 				B0DF03312283FFD8000F9492 /* PlaceholderTextView.swift in Sources */,
 				0A35BA9E22836CCF00AA5E2F /* ContactsSynchronizer.swift in Sources */,

--- a/Tinodios/KeyboardInfo.swift
+++ b/Tinodios/KeyboardInfo.swift
@@ -9,13 +9,13 @@
 import UIKit
 
 struct KeyboardInfo {
-    
+
     let frameBegin: CGRect
     let frameEnd: CGRect
     let isLocal: Bool
     let animationDuration: TimeInterval
     let animationCurve: UIView.AnimationCurve
-    
+
     init?(notification: Notification) {
         guard
             let userInfo = notification.userInfo,
@@ -26,14 +26,14 @@ struct KeyboardInfo {
             let rawCurve = userInfo[UIResponder.keyboardAnimationCurveUserInfoKey] as? Int,
             let animationCurve = UIView.AnimationCurve(rawValue: rawCurve)
             else { return nil }
-        
+
         self.frameBegin = frameBegin
         self.frameEnd = frameEnd
         self.isLocal = isLocal
         self.animationDuration = animationDuration
         self.animationCurve = animationCurve
     }
-    
+
     var animationOptions: UIView.AnimationOptions {
         let option = animationCurve.rawValue << 16
         return UIView.AnimationOptions(rawValue: UInt(option))

--- a/Tinodios/KeyboardInfo.swift
+++ b/Tinodios/KeyboardInfo.swift
@@ -1,0 +1,41 @@
+//
+//  KeyboardInfo.swift
+//  Tinodios
+//
+//  Created by Nikita Timonin on 24/11/2019.
+//  Copyright © 2019 Tinode. All rights reserved.
+//
+
+import UIKit
+
+struct KeyboardInfo {
+    
+    let frameBegin: CGRect
+    let frameEnd: CGRect
+    let isLocal: Bool
+    let animationDuration: TimeInterval
+    let animationCurve: UIView.AnimationCurve
+    
+    init?(notification: Notification) {
+        guard
+            let userInfo = notification.userInfo,
+            let frameBegin = userInfo[UIResponder.keyboardFrameBeginUserInfoKey] as? CGRect,
+            let frameEnd = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
+            let isLocal = userInfo[UIResponder.keyboardIsLocalUserInfoKey] as? Bool,
+            let animationDuration = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? TimeInterval,
+            let rawCurve = userInfo[UIResponder.keyboardAnimationCurveUserInfoKey] as? Int,
+            let animationCurve = UIView.AnimationCurve(rawValue: rawCurve)
+            else { return nil }
+        
+        self.frameBegin = frameBegin
+        self.frameEnd = frameEnd
+        self.isLocal = isLocal
+        self.animationDuration = animationDuration
+        self.animationCurve = animationCurve
+    }
+    
+    var animationOptions: UIView.AnimationOptions {
+        let option = animationCurve.rawValue << 16
+        return UIView.AnimationOptions(rawValue: UInt(option))
+    }
+}

--- a/Tinodios/MessageView.swift
+++ b/Tinodios/MessageView.swift
@@ -57,7 +57,7 @@ class MessageView: UICollectionView {
     }
 
     func scrollToBottom(animated: Bool = false) {
-        let contentHeight = contentSize.height //collectionViewLayout.collectionViewContentSize.height
+        let contentHeight = collectionViewLayout.collectionViewContentSize.height
         performBatchUpdates(nil) { _ in
             self.scrollRectToVisible(CGRect(x: 0, y: contentHeight - 1, width: 1, height: 1), animated: animated)
         }

--- a/Tinodios/MessageViewController+Keyboard.swift
+++ b/Tinodios/MessageViewController+Keyboard.swift
@@ -37,7 +37,10 @@ extension MessageViewController {
         let overlap: CGFloat
 
         if collectionView.contentSize.height > collectionView.bounds.height - inputAccessoryViewHeight {
-            overlap = collectionView.bounds.height - keyboardInfo.frameEnd.origin.y
+            overlap =
+                collectionView.bounds.height
+                - keyboardInfo.frameEnd.origin.y
+                - inputAccessoryViewHeight
         } else {
             overlap =
                 collectionView.contentSize.height

--- a/Tinodios/MessageViewController+Keyboard.swift
+++ b/Tinodios/MessageViewController+Keyboard.swift
@@ -29,12 +29,12 @@ extension MessageViewController {
             let keyboardInfo = KeyboardInfo(notification: notification),
             !keyboardInfo.frameBegin.isEmpty
         else { return }
-        
+
         let change: CGFloat = keyboardInfo.frameEnd.height
         collectionView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: change, right: 0)
-        
+
         let overlap: CGFloat
-        
+
         if collectionView.contentSize.height > collectionView.bounds.height {
             overlap = collectionView.bounds.height - keyboardInfo.frameEnd.origin.y
         } else {
@@ -43,7 +43,7 @@ extension MessageViewController {
                 - collectionView.contentOffset.y
                 - keyboardInfo.frameEnd.origin.y
         }
-        
+
         if overlap > 0 {
             let contentOffset = CGPoint(
                 x: collectionView.contentOffset.x,
@@ -51,7 +51,7 @@ extension MessageViewController {
             collectionView.setContentOffset(contentOffset, animated: false)
         }
     }
-    
+
     @objc private func keyboardWillHide(_ notification: Notification) {
         collectionView.contentInset = .zero
     }

--- a/Tinodios/MessageViewController+Keyboard.swift
+++ b/Tinodios/MessageViewController+Keyboard.swift
@@ -43,6 +43,7 @@ extension MessageViewController {
                 collectionView.contentSize.height
                 - collectionView.contentOffset.y
                 - keyboardInfo.frameEnd.origin.y
+                + inputAccessoryViewHeight
         }
 
         if overlap > 0 && keyboardInfo.frameEnd.size.height != inputAccessoryViewHeight {

--- a/Tinodios/MessageViewController+Keyboard.swift
+++ b/Tinodios/MessageViewController+Keyboard.swift
@@ -10,48 +10,50 @@ import UIKit
 extension MessageViewController {
 
     func addKeyboardObservers() {
-        NotificationCenter.default.addObserver(self, selector: #selector(adjustForKeyboard), name: UIResponder.keyboardWillHideNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(adjustForKeyboard), name: UIResponder.keyboardWillChangeFrameNotification, object: nil)
+        let notificationCenter = NotificationCenter.default
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(adjustForKeyboard(_:)),
+            name: UIResponder.keyboardWillChangeFrameNotification,
+            object: nil)
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(keyboardWillHide(_:)),
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil)
     }
 
-    func removeKeyboardObservers() {
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillChangeFrameNotification, object: nil)
-        NotificationCenter.default.removeObserver(self, name: UITextView.keyboardWillHideNotification, object: nil)
-    }
-
-    @objc func adjustForKeyboard(notification: Notification) {
+    @objc func adjustForKeyboard(_ notification: Notification) {
         // Apparently there is a bug in iOS 11 on iPad which sends useless notifications. This is a workaround.
-        guard let keyboardScreenStart = notification.userInfo?[UIResponder.keyboardFrameBeginUserInfoKey] as? CGRect else { return }
-        guard !keyboardScreenStart.isEmpty else { return }
-
-        guard let keyboardValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else { return }
-        let keyboardScreenEndFrame = keyboardValue.cgRectValue
-        let keyboardViewEndFrame = view.convert(keyboardScreenEndFrame, from: view.window)
-
-        if notification.name == UIResponder.keyboardWillHideNotification {
-            collectionView.contentInset = .zero
+        guard
+            let keyboardInfo = KeyboardInfo(notification: notification),
+            !keyboardInfo.frameBegin.isEmpty
+        else { return }
+        
+        let change: CGFloat = keyboardInfo.frameEnd.height
+        collectionView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: change, right: 0)
+        
+        let overlap: CGFloat
+        
+        if collectionView.contentSize.height > collectionView.bounds.height {
+            overlap = collectionView.bounds.height - keyboardInfo.frameEnd.origin.y
         } else {
-            let change: CGFloat
-            if #available(iOS 11.0, *) {
-                change = keyboardViewEndFrame.height - view.safeAreaInsets.bottom
-            } else {
-                change = keyboardViewEndFrame.height
-            }
-
-            collectionView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: change, right: 0)
+            overlap =
+                collectionView.contentSize.height
+                - collectionView.contentOffset.y
+                - keyboardInfo.frameEnd.origin.y
         }
-        // Inset of the same size as the keyboard minus the bottom safe area inset.
-        collectionView.scrollIndicatorInsets = self.collectionView.contentInset
-
-        // How much do we need to scroll up to maintain the same scroll position relative to the bottom of the view
-        let contentBottom = collectionView.frame.origin.y + collectionView.contentSize.height - collectionView.contentOffset.y
-        let overlap = contentBottom - keyboardViewEndFrame.origin.y
-
-        // Scroll the view to maintain the current position.
+        
         if overlap > 0 {
-            let contentOffset = CGPoint(x: collectionView.contentOffset.x, y: collectionView.contentOffset.y + overlap)
+            let contentOffset = CGPoint(
+                x: collectionView.contentOffset.x,
+                y: collectionView.contentOffset.y + overlap)
             collectionView.setContentOffset(contentOffset, animated: false)
         }
+    }
+    
+    @objc private func keyboardWillHide(_ notification: Notification) {
+        collectionView.contentInset = .zero
     }
 
     private var bottomInset: CGFloat {

--- a/Tinodios/MessageViewController+Keyboard.swift
+++ b/Tinodios/MessageViewController+Keyboard.swift
@@ -32,10 +32,11 @@ extension MessageViewController {
 
         let change: CGFloat = keyboardInfo.frameEnd.height
         collectionView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: change, right: 0)
+        let inputAccessoryViewHeight = inputAccessoryView?.frame.height ?? 0
 
         let overlap: CGFloat
 
-        if collectionView.contentSize.height > collectionView.bounds.height {
+        if collectionView.contentSize.height > collectionView.bounds.height - inputAccessoryViewHeight {
             overlap = collectionView.bounds.height - keyboardInfo.frameEnd.origin.y
         } else {
             overlap =
@@ -44,7 +45,7 @@ extension MessageViewController {
                 - keyboardInfo.frameEnd.origin.y
         }
 
-        if overlap > 0 {
+        if overlap > 0 && keyboardInfo.frameEnd.size.height != inputAccessoryViewHeight {
             let contentOffset = CGPoint(
                 x: collectionView.contentOffset.x,
                 y: collectionView.contentOffset.y + overlap)
@@ -53,7 +54,7 @@ extension MessageViewController {
     }
 
     @objc private func keyboardWillHide(_ notification: Notification) {
-        collectionView.contentInset = .zero
+        collectionView.contentInset.bottom = inputAccessoryView?.frame.height ?? 0
     }
 
     private var bottomInset: CGFloat {

--- a/Tinodios/MessageViewController.swift
+++ b/Tinodios/MessageViewController.swift
@@ -271,8 +271,7 @@ class MessageViewController: UIViewController {
         let top = collectionView.topAnchor.constraint(equalTo: view.topAnchor, constant: topLayoutGuide.length)
         let trailing: NSLayoutConstraint, leading: NSLayoutConstraint, bottom: NSLayoutConstraint
         if #available(iOS 11, *) {
-            // Extra padding as -50. It's probably due to a bug somewhere.
-            bottom = collectionView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -50)
+            bottom = collectionView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
             leading = collectionView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor)
             trailing = collectionView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
         } else {

--- a/Tinodios/MessageViewController.swift
+++ b/Tinodios/MessageViewController.swift
@@ -227,7 +227,6 @@ class MessageViewController: UIViewController {
     // MARK: lifecycle
 
     deinit {
-        removeKeyboardObservers()
         // removeMenuControllerObservers()
         removeAppStateObservers()
         // Clean up.

--- a/Tinodios/MessageViewController.swift
+++ b/Tinodios/MessageViewController.swift
@@ -319,14 +319,12 @@ class MessageViewController: UIViewController {
     @objc private func processNotifications() {
         self.interactor?.sendReadNotification()
     }
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        if #available(iOS 11, *) {
-        } else {
-            // iOS 9-10: Make sure messages don't hide behind sendMessageBar.
-            collectionView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: self.sendMessageBar.frame.height, right: 0)
-        }
+        collectionView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: sendMessageBar.frame.height, right: 0)
+        
         self.interactor?.attachToTopic()
         self.interactor?.loadMessages()
         self.interactor?.sendReadNotification()


### PR DESCRIPTION
This pull request have following purposes: 

1. Fix the issue when collectionView will scroll all the way down when keyboard appears by calculating correct value to add to `collectionView.contentOffset.y` on keyboard appearance. 
2. Make the code more compact and clear, by adding a separate util struct to get all necessary info about the keyboard and its frame. 
3. Remove unnecessary code like `removeKeyboardObservers` - it is not needed anymore since iOS9. 