### PR TITLE
Handle universal links (to *.tinode.co).

### DIFF
--- a/Tinodios/AppDelegate.swift
+++ b/Tinodios/AppDelegate.swift
@@ -126,6 +126,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             completionHandler(.noData)
         }
     }
+
+    func application(_ application: UIApplication,
+                     continue userActivity: NSUserActivity,
+                     restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
+        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+            let url = userActivity.webpageURL,
+            let components = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
+            return false
+        }
+        if (components.host?.hasSuffix("tinode.co") ?? false) {
+            // Start the app.
+            return true
+        }
+        return false
+    }
 }
 
 @available(iOS 10.0, *)

--- a/Tinodios/AppDelegate.swift
+++ b/Tinodios/AppDelegate.swift
@@ -135,6 +135,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             let components = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
             return false
         }
+        // TODO: support 3rd party urls.
         if (components.host?.hasSuffix("tinode.co") ?? false) {
             // Start the app.
             return true

--- a/Tinodios/Tinodios.entitlements
+++ b/Tinodios/Tinodios.entitlements
@@ -4,6 +4,10 @@
 <dict>
 	<key>aps-environment</key>
 	<string>production</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:*.tinode.co</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.co.tinode.tinodios.db</string>


### PR DESCRIPTION
This change will also need configuration on the server.