### PR TITLE
Pass message headers to Tinode.publish explicitly.

### DIFF
--- a/TinodeSDK/Storage.swift
+++ b/TinodeSDK/Storage.swift
@@ -11,6 +11,9 @@ public protocol Message {
     // Get current message payload.
     var content: Drafty? { get }
 
+    // Message headers.
+    var head: [String: JSONValue]? { get }
+
     // Timestamp
     var ts: Date? { get }
 
@@ -121,18 +124,20 @@ public protocol Storage: class {
     // Params:
     //   topic: topic which sent the message.
     //   data: message data to save.
+    //   head: message headers.
     // Returns:
     //   database ID of the message suitable for use in.
-    func msgSend(topic: TopicProto, data: Drafty) -> Int64
+    func msgSend(topic: TopicProto, data: Drafty, head: [String: JSONValue]?) -> Int64
 
     // Save message to database as a draft.
     // Draft will not be sent to server until it status changes.
     // Params:
     //   topic: topic which sent the message.
     //   data: message data to save.
+    //   head: message headers.
     // Returns:
     //   database ID of the message suitable for use in
-    func msgDraft(topic: TopicProto, data: Drafty) -> Int64
+    func msgDraft(topic: TopicProto, data: Drafty, head: [String: JSONValue]?) -> Int64
 
     // Update message draft content without
     // Params:

--- a/TinodeSDK/Tinode.swift
+++ b/TinodeSDK/Tinode.swift
@@ -1060,8 +1060,9 @@ public class Tinode {
         return sendWithPromise(payload: msg, with: msgId)
     }
 
-    public static func draftyHeaders(for message: Drafty) -> [String: JSONValue] {
-        var head = [String: JSONValue]()
+    public static func draftyHeaders(for message: Drafty) -> [String: JSONValue]? {
+        guard !message.isPlain else { return nil }
+        var head: [String: JSONValue] = [:]
         head["mime"] = JSONValue.string(Drafty.kMimeType)
         if let refs = message.getEntReferences() {
             head["attachments"] = JSONValue.array(refs.map { JSONValue.string($0) })

--- a/TinodeSDK/Tinode.swift
+++ b/TinodeSDK/Tinode.swift
@@ -1060,18 +1060,28 @@ public class Tinode {
         return sendWithPromise(payload: msg, with: msgId)
     }
 
-    internal func publish(topic: String, head: [String:JSONValue]?, content: Drafty) -> PromisedReply<ServerMessage>? {
+    public static func draftyHeaders(for message: Drafty) -> [String: JSONValue] {
+        var head = [String: JSONValue]()
+        head["mime"] = JSONValue.string(Drafty.kMimeType)
+        if let refs = message.getEntReferences() {
+            head["attachments"] = JSONValue.array(refs.map { JSONValue.string($0) })
+        }
+        return head
+    }
+
+    public func publish(topic: String, head: [String:JSONValue]?, content: Drafty) -> PromisedReply<ServerMessage>? {
         let msgId = getNextMsgId()
         let msg = ClientMessage<Int, Int>(
             pub: MsgClientPub(id: msgId, topic: topic, noecho: true, head: head, content: content))
         return sendWithPromise(payload: msg, with: msgId)
     }
-
+    /*
     public func publish(topic: String, data: Drafty) -> PromisedReply<ServerMessage>? {
         return publish(topic: topic,
                        head: data.isPlain ? nil : ["mime": JSONValue.string(Drafty.kMimeType)],
                        content: data)
     }
+    */
     public func getTopics() -> Array<TopicProto>? {
         return Array(topics.values)
     }

--- a/TinodeSDK/Tinode.swift
+++ b/TinodeSDK/Tinode.swift
@@ -1075,13 +1075,7 @@ public class Tinode {
             pub: MsgClientPub(id: msgId, topic: topic, noecho: true, head: head, content: content))
         return sendWithPromise(payload: msg, with: msgId)
     }
-    /*
-    public func publish(topic: String, data: Drafty) -> PromisedReply<ServerMessage>? {
-        return publish(topic: topic,
-                       head: data.isPlain ? nil : ["mime": JSONValue.string(Drafty.kMimeType)],
-                       content: data)
-    }
-    */
+
     public func getTopics() -> Array<TopicProto>? {
         return Array(topics.values)
     }

--- a/Tinodios/MessageInteractor.swift
+++ b/Tinodios/MessageInteractor.swift
@@ -344,7 +344,7 @@ class MessageInteractor: DefaultComTopic.Listener, MessageBusinessLogic, Message
                                                 fname: filename,
                                                 refurl: refurl,
                                                 size: data.count) else { return }
-        if let msgId = topic.store?.msgDraft(topic: topic, data: content) {
+        if let msgId = topic.store?.msgDraft(topic: topic, data: content, head: Tinode.draftyHeaders(for: content)) {
             let helper = Cache.getLargeFileHelper()
             helper.startUpload(
                 filename: filename, mimetype: mimeType, d: data,

--- a/Tinodios/TopicInfoViewController.swift
+++ b/Tinodios/TopicInfoViewController.swift
@@ -366,10 +366,11 @@ class TopicInfoViewController: UITableViewController {
         blockContact();
         let tinode = Cache.getTinode()
         // Create and send spam report.
-        _ = tinode.publish(topic: Tinode.kTopicSys, data: Drafty().attachJSON([
+        let msg = Drafty().attachJSON([
             "action": JSONValue.string("report"),
             "target": JSONValue.string(self.topic.name)
-            ]))
+            ])
+        _ = tinode.publish(topic: Tinode.kTopicSys, head: Tinode.draftyHeaders(for: msg), content: msg)
     }
 
     @objc func deleteGroupClicked(sender: UITapGestureRecognizer) {

--- a/TinodiosDB/SqlStore.swift
+++ b/TinodiosDB/SqlStore.swift
@@ -187,7 +187,7 @@ public class SqlStore : Storage {
             return -1
         }
     }
-    private func insertMessage(topic: TopicProto, data: Drafty, initialStatus: Int) -> Int64 {
+    private func insertMessage(topic: TopicProto, data: Drafty, head: [String: JSONValue]?, initialStatus: Int) -> Int64 {
         let msg = StoredMessage()
         msg.topic = topic.name
         msg.from = myUid
@@ -195,6 +195,7 @@ public class SqlStore : Storage {
         msg.seq = 0
         msg.status = initialStatus
         msg.content = data
+        msg.head = head
         msg.topicId = (topic.payload as? StoredTopic)?.id ?? -1
         if myId < 0 {
             myId = self.dbh?.userDb?.getId(for: msg.from) ?? -1
@@ -203,12 +204,12 @@ public class SqlStore : Storage {
         return self.dbh?.messageDb?.insert(topic: topic, msg: msg) ?? -1
     }
 
-    public func msgSend(topic: TopicProto, data: Drafty) -> Int64 {
-        return self.insertMessage(topic: topic, data: data, initialStatus: BaseDb.kStatusUndefined)
+    public func msgSend(topic: TopicProto, data: Drafty, head: [String: JSONValue]?) -> Int64 {
+        return self.insertMessage(topic: topic, data: data, head: head, initialStatus: BaseDb.kStatusUndefined)
     }
 
-    public func msgDraft(topic: TopicProto, data: Drafty) -> Int64 {
-        return self.insertMessage(topic: topic, data: data, initialStatus: BaseDb.kStatusDraft)
+    public func msgDraft(topic: TopicProto, data: Drafty, head: [String: JSONValue]?) -> Int64 {
+        return self.insertMessage(topic: topic, data: data, head: head, initialStatus: BaseDb.kStatusDraft)
     }
 
     public func msgDraftUpdate(topic: TopicProto, dbMessageId: Int64, data: Drafty) -> Bool {


### PR DESCRIPTION
Needed in order to correctly save message headers for outgoing messages.