### PR TITLE
Cleanup of PromisedReplies, credentials work now

### DIFF
--- a/TinodeSDK.xcodeproj/project.pbxproj
+++ b/TinodeSDK.xcodeproj/project.pbxproj
@@ -159,17 +159,17 @@
 			isa = PBXGroup;
 			children = (
 				0A431BE72244A14B00A837F7 /* JSONValue.swift */,
-				0A81B316236FA896009AF14B /* Types.swift */,
 				0A431BE82244A14B00A837F7 /* Acs.swift */,
 				0A431BE92244A14B00A837F7 /* AcsHelper.swift */,
 				0A431BEA2244A14B00A837F7 /* ClientMessages.swift */,
 				0A431BEB2244A14B00A837F7 /* Defacs.swift */,
 				0A431BEC2244A14B00A837F7 /* Description.swift */,
 				0A431BED2244A14B00A837F7 /* Drafty.swift */,
+				0AAF8BEB23B70E2A00C9CFBB /* MsgRange.swift */,
 				0A431BEE2244A14B00A837F7 /* ServerMessages.swift */,
 				0A431BEF2244A14B00A837F7 /* Subscription.swift */,
+				0A81B316236FA896009AF14B /* Types.swift */,
 				0A431BF02244A14B00A837F7 /* VCard.swift */,
-				0AAF8BEB23B70E2A00C9CFBB /* MsgRange.swift */,
 			);
 			path = model;
 			sourceTree = "<group>";

--- a/TinodeSDK/FndTopic.swift
+++ b/TinodeSDK/FndTopic.swift
@@ -14,7 +14,7 @@ public class FndTopic<SP: Codable>: Topic<String, String, SP, Array<String>> {
     }
 
     @discardableResult
-    override public func setMeta(meta: MsgSetMeta<String, String>) -> PromisedReply<ServerMessage>? {
+    override public func setMeta(meta: MsgSetMeta<String, String>) -> PromisedReply<ServerMessage> {
         if self.subs != nil {
             self.subs!.removeAll()
             self.subs = nil

--- a/TinodeSDK/MeTopic.swift
+++ b/TinodeSDK/MeTopic.swift
@@ -47,7 +47,7 @@ open class MeTopic<DP: Codable & Mergeable>: Topic<DP, PrivateType, DP, PrivateT
         }
 
         let cred = Credential(meth: meth, val: val)
-        return try! tnd.delCredential(cred: cred).then(
+        return tnd.delCredential(cred: cred).then(
             onSuccess: { [weak self] msg in
                 let idx = self?.find(cred: cred, anyUnconfirmed: false) ?? -1
                 if idx >= 0 {
@@ -57,8 +57,7 @@ open class MeTopic<DP: Codable & Mergeable>: Topic<DP, PrivateType, DP, PrivateT
                 // Notify listeners
                 (self?.listener as! MeListener).onCredUpdated(cred: self?.creds)
                 return nil
-            },
-            onFailure: nil)
+            })
     }
 
     private func find(cred other: Credential, anyUnconfirmed: Bool) -> Int {

--- a/TinodeSDK/MeTopic.swift
+++ b/TinodeSDK/MeTopic.swift
@@ -306,7 +306,7 @@ open class MeTopic<DP: Codable & Mergeable>: Topic<DP, PrivateType, DP, PrivateT
                     credentials!.append(cred)
                 } else {
                     // Found. Maybe change 'done' status.
-                    credentials?[idx].done = true
+                    credentials?[idx].done = cred.isDone
                 }
             }
         } else if cred.resp != nil && credentials != nil {

--- a/TinodeSDK/PromisedReply.swift
+++ b/TinodeSDK/PromisedReply.swift
@@ -157,11 +157,11 @@ public class PromisedReply<Value> {
         }
     }
     @discardableResult
-    public func thenApply(onSuccess successHandler: SuccessHandler) -> PromisedReply<Value>? {
+    public func thenApply(onSuccess successHandler: SuccessHandler) -> PromisedReply<Value> {
         return then(onSuccess: successHandler, onFailure: nil)
     }
     @discardableResult
-    public func thenCatch(onFailure failureHandler: FailureHandler) -> PromisedReply<Value>? {
+    public func thenCatch(onFailure failureHandler: FailureHandler) -> PromisedReply<Value> {
         return then(onSuccess: nil, onFailure: failureHandler)
     }
 

--- a/TinodeSDK/PromisedReply.swift
+++ b/TinodeSDK/PromisedReply.swift
@@ -134,7 +134,7 @@ public class PromisedReply<Value> {
     }
     @discardableResult
     public func then(onSuccess successHandler: SuccessHandler,
-                     onFailure failureHandler: FailureHandler = nil) throws -> PromisedReply<Value>? {
+                     onFailure failureHandler: FailureHandler = nil) throws -> PromisedReply<Value> {
         return try queue.sync {
             // start critical section
             guard nextPromise == nil else {
@@ -152,9 +152,9 @@ public class PromisedReply<Value> {
                 case .waiting: break
                 }
             } catch {
-                nextPromise = PromisedReply<Value>(error: error)
+                self.nextPromise = PromisedReply<Value>(error: error)
             }
-            return nextPromise
+            return self.nextPromise!
         }
     }
     @discardableResult

--- a/TinodeSDK/PromisedReply.swift
+++ b/TinodeSDK/PromisedReply.swift
@@ -157,15 +157,15 @@ public class PromisedReply<Value> {
         }
     }
     @discardableResult
-    public func thenApply(onSuccess successHandler: SuccessHandler) -> PromisedReply<Value> {
+    public func thenApply(_ successHandler: SuccessHandler) -> PromisedReply<Value> {
         return then(onSuccess: successHandler, onFailure: nil)
     }
     @discardableResult
-    public func thenCatch(onFailure failureHandler: FailureHandler) -> PromisedReply<Value> {
+    public func thenCatch(_ failureHandler: FailureHandler) -> PromisedReply<Value> {
         return then(onSuccess: nil, onFailure: failureHandler)
     }
 
-    public func thenFinally(finally: @escaping FinallyHandler) {
+    public func thenFinally(_ finally: @escaping FinallyHandler) {
         then(
             onSuccess: {
                 msg in try finally()

--- a/TinodeSDK/PromisedReply.swift
+++ b/TinodeSDK/PromisedReply.swift
@@ -133,12 +133,11 @@ public class PromisedReply<Value> {
         }
     }
     @discardableResult
-    public func then(onSuccess successHandler: SuccessHandler,
-                     onFailure failureHandler: FailureHandler = nil) throws -> PromisedReply<Value> {
-        return try queue.sync {
+    public func then(onSuccess successHandler: SuccessHandler, onFailure failureHandler: FailureHandler = nil) -> PromisedReply<Value> {
+        return queue.sync {
             // start critical section
             guard nextPromise == nil else {
-                throw PromisedReplyError.illegalStateError("Multiple calls to then are not supported")
+                fatalError("Multiple calls to then are not supported")
             }
             self.successHandler = successHandler
             self.failureHandler = failureHandler
@@ -158,18 +157,16 @@ public class PromisedReply<Value> {
         }
     }
     @discardableResult
-    public func thenApply(onSuccess successHandler: SuccessHandler)
-        throws -> PromisedReply<Value>? {
-        return try then(onSuccess: successHandler, onFailure: nil)
+    public func thenApply(onSuccess successHandler: SuccessHandler) -> PromisedReply<Value>? {
+        return then(onSuccess: successHandler, onFailure: nil)
     }
     @discardableResult
-    public func thenCatch(onFailure failureHandler: FailureHandler)
-        throws -> PromisedReply<Value>? {
-        return try then(onSuccess: nil, onFailure: failureHandler)
+    public func thenCatch(onFailure failureHandler: FailureHandler) -> PromisedReply<Value>? {
+        return then(onSuccess: nil, onFailure: failureHandler)
     }
 
-    public func thenFinally(finally: @escaping FinallyHandler) throws {
-        try then(
+    public func thenFinally(finally: @escaping FinallyHandler) {
+        then(
             onSuccess: {
                 msg in try finally()
                 return nil

--- a/TinodeSDK/Tinode.swift
+++ b/TinodeSDK/Tinode.swift
@@ -560,8 +560,8 @@ public class Tinode {
     private func hello() -> PromisedReply<ServerMessage> {
         let msgId = getNextMsgId()
         let msg = ClientMessage<Int, Int>(hi: MsgClientHi(id: msgId, ver: kVersion, ua: userAgent, dev: deviceToken, lang: kLocale))
-        return sendWithPromise(payload: msg, with: msgId).thenApply(
-            onSuccess: { [weak self] pkt in
+        return sendWithPromise(payload: msg, with: msgId)
+            .thenApply({ [weak self] pkt in
                 guard let ctrl = pkt?.ctrl else {
                     throw TinodeError.invalidReply("Unexpected type of reply packet to hello")
                 }
@@ -1112,13 +1112,13 @@ public class Tinode {
             deviceToken = Tinode.isNull(obj: token) ? nil : token
             let msgId = getNextMsgId()
             let msg = ClientMessage<Int, Int>(hi: MsgClientHi(id: msgId, dev: token))
-            return sendWithPromise(payload: msg, with: msgId).thenCatch(
-                onFailure: { [weak self] err in
+            return sendWithPromise(payload: msg, with: msgId)
+                .thenCatch { [weak self] err in
                     // Clear cached value on failure to allow for retries.
                     self?.deviceToken = nil
                     self?.store?.deviceToken = nil
                     return nil
-            })
+                }
         }
     }
 

--- a/TinodeSDK/Tinode.swift
+++ b/TinodeSDK/Tinode.swift
@@ -1200,30 +1200,41 @@ public class Tinode {
         guard let msgId = msg.del?.id else { return nil }
         return sendWithPromise(payload: msg, with: msgId)
     }
-    func delMessage(topicName: String?, fromId: Int, toId: Int?, hard: Bool) -> PromisedReply<ServerMessage>? {
+    func delMessage(topicName: String, fromId: Int, toId: Int?, hard: Bool) -> PromisedReply<ServerMessage>? {
         return sendDeleteMessage(
             msg: ClientMessage<Int, Int>(
                 del: MsgClientDel(id: getNextMsgId(),
                                   topic: topicName,
                                   from: fromId, to: toId, hard: hard)))
     }
-    func delMessage(topicName: String?, ranges: [MsgRange]?, hard: Bool) -> PromisedReply<ServerMessage>? {
+    func delMessage(topicName: String, ranges: [MsgRange]?, hard: Bool) -> PromisedReply<ServerMessage>? {
         return sendDeleteMessage(
             msg: ClientMessage<Int, Int>(
                 del: MsgClientDel(id: getNextMsgId(),
                                   topic: topicName, ranges: ranges, hard: hard)))
     }
-    func delMessage(topicName: String?, msgId: Int, hard: Bool) -> PromisedReply<ServerMessage>? {
+    func delMessage(topicName: String, msgId: Int, hard: Bool) -> PromisedReply<ServerMessage>? {
         return sendDeleteMessage(
             msg: ClientMessage<Int, Int>(
                 del: MsgClientDel(id: getNextMsgId(),
                                   topic: topicName, msgId: msgId, hard: hard)))
     }
-    func delSubscription(topicName: String?, user: String?) -> PromisedReply<ServerMessage>? {
+    func delSubscription(topicName: String, user: String?) -> PromisedReply<ServerMessage>? {
         return sendDeleteMessage(
             msg: ClientMessage<Int, Int>(
                 del: MsgClientDel(id: getNextMsgId(),
                                   topic: topicName, user: user)))
+    }
+
+    /// Low-level request to delete a credential. Use {@link MeTopic#delCredential(String, String)} ()} instead.
+    ///
+    /// - Parameters
+    ///  - cred  credential to delete.
+    /// - Returns: PromisedReply of the reply ctrl message
+    func delCredential(cred: Credential) -> PromisedReply<ServerMessage> {
+        let msgId = getNextMsgId()
+        let msg = ClientMessage<Int, Int>(del: MsgClientDel(id: msgId, cred: cred))
+        return sendWithPromise(payload: msg, with: msgId)
     }
 
     /// Low-level request to delete topic. Use {@link Topic#delete()} instead.
@@ -1231,7 +1242,7 @@ public class Tinode {
     /// - Parameters:
     ///   - topicName: name of the topic to delete
     /// - Returns: PromisedReply of the reply ctrl message
-    func delTopic(topicName: String?) -> PromisedReply<ServerMessage>? {
+    func delTopic(topicName: String) -> PromisedReply<ServerMessage>? {
         let msgId = getNextMsgId()
         let msg = ClientMessage<Int, Int>(del: MsgClientDel(id: msgId, topic: topicName))
         return sendWithPromise(payload: msg, with: msgId)

--- a/TinodeSDK/Topic.swift
+++ b/TinodeSDK/Topic.swift
@@ -480,7 +480,7 @@ open class Topic<DP: Codable & Mergeable, DR: Codable & Mergeable, SP: Codable, 
     }
 
     @discardableResult
-    public func subscribe() -> PromisedReply<ServerMessage>? {
+    public func subscribe() -> PromisedReply<ServerMessage> {
         var setMsg: MsgSetMeta<DP, DR>? = nil
         var getMsg: MsgGetMeta? = nil
         if isNew {
@@ -495,11 +495,11 @@ open class Topic<DP: Codable & Mergeable, DR: Codable & Mergeable, SP: Codable, 
         return subscribe(set: setMsg, get: getMsg)
     }
     @discardableResult
-    public func subscribe(set: MsgSetMeta<DP, DR>?, get: MsgGetMeta?) -> PromisedReply<ServerMessage>? {
+    public func subscribe(set: MsgSetMeta<DP, DR>?, get: MsgGetMeta?) -> PromisedReply<ServerMessage> {
         return subscribe(set: set, get: get, background: false)
     }
     @discardableResult
-    public func subscribe(set: MsgSetMeta<DP, DR>?, get: MsgGetMeta?, background: Bool) -> PromisedReply<ServerMessage>? {
+    public func subscribe(set: MsgSetMeta<DP, DR>?, get: MsgGetMeta?, background: Bool) -> PromisedReply<ServerMessage> {
         if attached {
             // If the topic is already attached and the user
             // does not attempt to set or get any data,
@@ -520,7 +520,7 @@ open class Topic<DP: Codable & Mergeable, DR: Codable & Mergeable, SP: Codable, 
         guard tnd.isConnectionAuthenticated else {
             return PromisedReply(error: TinodeError.invalidState("Connection is not authenticated.") )
         }
-        return tnd.subscribe(to: name, set: set, get: get, background: background)?.then(
+        return tnd.subscribe(to: name, set: set, get: get, background: background).then(
             onSuccess: { [weak self] msg in
                 let isAttached = self?.attached ?? false
                 if !isAttached {
@@ -776,9 +776,9 @@ open class Topic<DP: Codable & Mergeable, DR: Codable & Mergeable, SP: Codable, 
 
     /// Delete topic
     @discardableResult
-    public func delete() -> PromisedReply<ServerMessage>? {
+    public func delete() -> PromisedReply<ServerMessage> {
         // Delete works even if the topic is not attached.
-        return tinode!.delTopic(topicName: name)?.then(
+        return tinode!.delTopic(topicName: name).then(
             onSuccess: { msg in
                 self.topicLeft(unsub: true, code: msg?.ctrl?.code, reason: msg?.ctrl?.text)
                 self.tinode!.stopTrackingTopic(topicName: self.name)
@@ -876,12 +876,12 @@ open class Topic<DP: Codable & Mergeable, DR: Codable & Mergeable, SP: Codable, 
     }
 
     @discardableResult
-    public func getMeta(query: MsgGetMeta) -> PromisedReply<ServerMessage>? {
-        return tinode?.getMeta(topic: name, query: query)
+    public func getMeta(query: MsgGetMeta) -> PromisedReply<ServerMessage> {
+        return tinode!.getMeta(topic: name, query: query)
     }
 
-    public func setMeta(meta: MsgSetMeta<DP, DR>) -> PromisedReply<ServerMessage>? {
-        return tinode?.setMeta(for: self.name, meta: meta)?.thenApply(
+    public func setMeta(meta: MsgSetMeta<DP, DR>) -> PromisedReply<ServerMessage> {
+        return tinode!.setMeta(for: self.name, meta: meta).thenApply(
             onSuccess: { msg in
                 if let ctrl = msg?.ctrl, ctrl.code < 300 {
                     self.update(ctrl: ctrl, meta: meta)
@@ -889,13 +889,13 @@ open class Topic<DP: Codable & Mergeable, DR: Codable & Mergeable, SP: Codable, 
                 return nil
             })
     }
-    public func setDescription(desc: MetaSetDesc<DP, DR>) -> PromisedReply<ServerMessage>? {
+    public func setDescription(desc: MetaSetDesc<DP, DR>) -> PromisedReply<ServerMessage> {
         return setMeta(meta: MsgSetMeta<DP, DR>(desc: desc, sub: nil, tags: nil, cred: nil))
     }
-    public func setDescription(pub: DP?, priv: DR?) -> PromisedReply<ServerMessage>? {
+    public func setDescription(pub: DP?, priv: DR?) -> PromisedReply<ServerMessage> {
         return setDescription(desc: MetaSetDesc<DP, DR>(pub: pub, priv: priv))
     }
-    public func updateDefacs(auth: String?, anon: String?) -> PromisedReply<ServerMessage>? {
+    public func updateDefacs(auth: String?, anon: String?) -> PromisedReply<ServerMessage> {
         let newdacs: Defacs
         if let olddacs = self.defacs {
             newdacs = Defacs(from: olddacs)
@@ -912,15 +912,15 @@ open class Topic<DP: Codable & Mergeable, DR: Codable & Mergeable, SP: Codable, 
         }
         return description!.acs!.update(from: ac)
     }
-    public func setSubscription(sub: MetaSetSub) -> PromisedReply<ServerMessage>? {
+    public func setSubscription(sub: MetaSetSub) -> PromisedReply<ServerMessage> {
         return setMeta(meta: MsgSetMeta(desc: nil, sub: sub, tags: nil, cred: nil))
     }
 
-    public func updateMode(update: String) -> PromisedReply<ServerMessage>? {
+    public func updateMode(update: String) -> PromisedReply<ServerMessage> {
         return updateMode(uid: nil, update: update)
     }
 
-    public func updateMode(uid: String?, update: String) -> PromisedReply<ServerMessage>? {
+    public func updateMode(uid: String?, update: String) -> PromisedReply<ServerMessage> {
         var uid = uid
         let sub = getSubscription(for: uid ?? tinode?.myUid)
         if uid == tinode?.myUid {
@@ -937,11 +937,11 @@ open class Topic<DP: Codable & Mergeable, DR: Codable & Mergeable, SP: Codable, 
         return PromisedReply<ServerMessage>(value: ServerMessage())
     }
 
-    public func updateMuted(muted: Bool) -> PromisedReply<ServerMessage>? {
+    public func updateMuted(muted: Bool) -> PromisedReply<ServerMessage> {
         return updateMode(uid: nil, update: muted ? "-P" : "+P")
     }
     @discardableResult
-    public func invite(user uid: String, in mode: String?) -> PromisedReply<ServerMessage>? {
+    public func invite(user uid: String, in mode: String?) -> PromisedReply<ServerMessage> {
         var sub = getSubscription(for: uid)
         if sub != nil {// : Subscription<SP, SR>
             sub!.acs?.given = mode != nil ? AcsHelper(str: mode) : nil
@@ -966,7 +966,7 @@ open class Topic<DP: Codable & Mergeable, DR: Codable & Mergeable, SP: Codable, 
         let metaSetSub = MetaSetSub(user: uid, mode: mode)
         //metaSetSub.user = uid
         //metaSetSub.mode = mode
-        return setMeta(meta: MsgSetMeta(desc: nil, sub: metaSetSub, tags: nil, cred: nil))?.thenApply(
+        return setMeta(meta: MsgSetMeta(desc: nil, sub: metaSetSub, tags: nil, cred: nil)).thenApply(
             onSuccess: { [weak self] msg in
                 if let topic = self {
                     topic.store?.subUpdate(topic: topic, sub: sub!)
@@ -977,7 +977,7 @@ open class Topic<DP: Codable & Mergeable, DR: Codable & Mergeable, SP: Codable, 
             })
     }
     @discardableResult
-    public func eject(user uid: String, ban: Bool) -> PromisedReply<ServerMessage>? {
+    public func eject(user uid: String, ban: Bool) -> PromisedReply<ServerMessage> {
         guard let sub = getSubscription(for: uid) else {
             return PromisedReply(error:
                 TinodeError.notSubscribed(
@@ -991,7 +991,7 @@ open class Topic<DP: Codable & Mergeable, DR: Codable & Mergeable, SP: Codable, 
             listener?.onSubsUpdated()
             return PromisedReply(error: TinodeError.notSynchronized)
         }
-        return tinode!.delSubscription(topicName: name, user: uid)?.thenApply(
+        return tinode!.delSubscription(topicName: name, user: uid).thenApply(
             onSuccess: { msg in
                 self.store?.subDelete(topic: self, sub: sub)
                 self.removeSubFromCache(sub: sub)
@@ -1066,9 +1066,9 @@ open class Topic<DP: Codable & Mergeable, DR: Codable & Mergeable, SP: Codable, 
         }
     }
     @discardableResult
-    public func leave(unsub: Bool? = false) -> PromisedReply<ServerMessage>? {
+    public func leave(unsub: Bool? = false) -> PromisedReply<ServerMessage> {
         if attached {
-            return tinode?.leave(topic: name, unsub: unsub)?
+            return tinode!.leave(topic: name, unsub: unsub)
                 .thenApply(
                     onSuccess: { [weak self] msg in
                         guard let s = self else {
@@ -1085,7 +1085,7 @@ open class Topic<DP: Codable & Mergeable, DR: Codable & Mergeable, SP: Codable, 
         if !(unsub ?? false) {
             return PromisedReply(value: ServerMessage())
         }
-        if tinode?.isConnected ?? false {
+        if tinode!.isConnected {
             return PromisedReply(error:
                 TinodeError.notSubscribed("Can't leave topic that I'm not subscribed to \(name)"))
         }
@@ -1113,12 +1113,12 @@ open class Topic<DP: Codable & Mergeable, DR: Codable & Mergeable, SP: Codable, 
         setRead(read: seq)
         store?.setRead(topic: self, read: seq)
     }
-    public func publish(content: Drafty, head: [String: JSONValue]?, msgId: Int64) -> PromisedReply<ServerMessage>? {
+    public func publish(content: Drafty, head: [String: JSONValue]?, msgId: Int64) -> PromisedReply<ServerMessage> {
         var headers = head
         if content.isPlain && headers?["mime"] != nil {
             headers?.removeValue(forKey: "mime")
         }
-        return tinode!.publish(topic: name, head: headers, content: content)?.then(
+        return tinode!.publish(topic: name, head: headers, content: content).then(
             onSuccess: { [weak self] msg in
                 self?.processDelivery(ctrl: msg?.ctrl, id: msgId)
                 return nil
@@ -1128,7 +1128,7 @@ open class Topic<DP: Codable & Mergeable, DR: Codable & Mergeable, SP: Codable, 
                 throw err
             })
     }
-    public func publish(content: Drafty) -> PromisedReply<ServerMessage>? {
+    public func publish(content: Drafty) -> PromisedReply<ServerMessage> {
         let head = !content.isPlain ? Tinode.draftyHeaders(for: content) : nil
         var id: Int64 = -1
         if let s = store {
@@ -1137,10 +1137,10 @@ open class Topic<DP: Codable & Mergeable, DR: Codable & Mergeable, SP: Codable, 
         if attached {
             return publish(content: content, head: head, msgId: id)
         } else {
-            return subscribe()?.thenApply(
+            return subscribe().thenApply(
                 onSuccess: { [weak self] msg in
                     return self?.publish(content: content, head: head, msgId: id)
-                })?.thenCatch(onFailure: { [weak self] err in
+                }).thenCatch(onFailure: { [weak self] err in
                     self?.store?.msgSyncing(topic: self!, dbMessageId: id, sync: false)
                     throw err
                 })
@@ -1148,8 +1148,8 @@ open class Topic<DP: Codable & Mergeable, DR: Codable & Mergeable, SP: Codable, 
     }
     private func sendPendingDeletes(hard: Bool) -> PromisedReply<ServerMessage>? {
         if let pendingDeletes = self.store?.getQueuedMessageDeletes(topic: self, hard: hard), !pendingDeletes.isEmpty {
-            return self.tinode?.delMessage(
-                topicName: self.name, ranges: pendingDeletes, hard: hard)?.thenApply(
+            return self.tinode!.delMessage(
+                topicName: self.name, ranges: pendingDeletes, hard: hard).thenApply(
                     onSuccess: { [weak self] msg in
                         if let id = msg?.ctrl?.getIntParam(for: "del"), let s = self {
                             s.clear = id
@@ -1162,10 +1162,10 @@ open class Topic<DP: Codable & Mergeable, DR: Codable & Mergeable, SP: Codable, 
         return nil
     }
 
-    private func delMessages(from fromId: Int, to toId: Int, hard: Bool) -> PromisedReply<ServerMessage>? {
+    private func delMessages(from fromId: Int, to toId: Int, hard: Bool) -> PromisedReply<ServerMessage> {
         store?.msgMarkToDelete(topic: self, from: fromId, to: toId, markAsHard: hard)
         if attached {
-            return tinode?.delMessage(topicName: self.name, fromId: fromId, toId: toId, hard: hard)?.then(
+            return tinode!.delMessage(topicName: self.name, fromId: fromId, toId: toId, hard: hard).then(
                 onSuccess: { [weak self] msg in
                     if let s = self, let delId = msg?.ctrl?.getIntParam(for: "del"), delId > 0 {
                         s.clear = delId
@@ -1181,29 +1181,29 @@ open class Topic<DP: Codable & Mergeable, DR: Codable & Mergeable, SP: Codable, 
         return PromisedReply<ServerMessage>(error: TinodeError.notConnected("Tinode not connected."))
     }
 
-    public func delMessages(hard: Bool) -> PromisedReply<ServerMessage>? {
+    public func delMessages(hard: Bool) -> PromisedReply<ServerMessage> {
         return delMessages(from: 0, to: (self.seq ?? 0) + 1, hard: hard)
     }
 
-    public func delMessage(id: Int, hard: Bool)  -> PromisedReply<ServerMessage>? {
+    public func delMessage(id: Int, hard: Bool)  -> PromisedReply<ServerMessage> {
         return delMessages(from: id, to: id + 1, hard: hard)
     }
 
-    public func syncOne(msgId: Int64) -> PromisedReply<ServerMessage>? {
+    public func syncOne(msgId: Int64) -> PromisedReply<ServerMessage> {
         guard let m = store?.getMessageById(topic: self, dbMessageId: msgId) else {
             return PromisedReply<ServerMessage>(value: ServerMessage())
         }
         if m.isDeleted {
-            return tinode?.delMessage(topicName: name, msgId: m.seqId, hard: m.isDeleted(hard: true))
+            return tinode!.delMessage(topicName: name, msgId: m.seqId, hard: m.isDeleted(hard: true))
         }
         if m.isReady, let content = m.content {
             store?.msgSyncing(topic: self, dbMessageId: msgId, sync: true)
             return self.publish(content: content, head: m.head, msgId: msgId)
         }
-        return nil
+        return PromisedReply<ServerMessage>(value: ServerMessage())
     }
-    public func syncAll() -> PromisedReply<ServerMessage>? {
-        var result: PromisedReply<ServerMessage>? = PromisedReply<ServerMessage>(value: ServerMessage())
+    public func syncAll() -> PromisedReply<ServerMessage> {
+        var result: PromisedReply<ServerMessage> = PromisedReply<ServerMessage>(value: ServerMessage())
         // Soft deletes.
         if let r = self.sendPendingDeletes(hard: false) {
             result = r
@@ -1212,6 +1212,7 @@ open class Topic<DP: Codable & Mergeable, DR: Codable & Mergeable, SP: Codable, 
         if let r = self.sendPendingDeletes(hard: true) {
             result = r
         }
+
         // Pending messages.
         guard let pendingMsgs = self.store?.getQueuedMessages(topic: self) else {
             return result

--- a/TinodeSDK/Topic.swift
+++ b/TinodeSDK/Topic.swift
@@ -114,7 +114,7 @@ open class Topic<DP: Codable & Mergeable, DR: Codable & Mergeable, SP: Codable, 
         open func onPres(pres: MsgServerPres) {}
         // {pres what="on|off"} is received.
         open func onOnline(online: Bool) {}
-        // Called by MeTopic when topic descriptor as contact is updated.
+        // Topic descriptor as contact is updated.
         open func onContUpdate(sub: Subscription<SP, SR>) {}
     }
 
@@ -745,6 +745,12 @@ open class Topic<DP: Codable & Mergeable, DR: Codable & Mergeable, SP: Codable, 
         self.update(tags: tags)
         listener?.onMetaTags(tags: tags)
     }
+    internal func routeMetaCred(cred: [Credential]) {
+        // Do nothing. All processing is in MeTopic in an overridden method.
+    }
+    internal func routeMetaCred(cred: Credential) {
+        // Do nothing. All processing is in MeTopic in an overridden method.
+    }
     public func routeMeta(meta: MsgServerMeta) {
         if meta.desc != nil {
             routeMetaDesc(meta: meta)
@@ -760,6 +766,9 @@ open class Topic<DP: Codable & Mergeable, DR: Codable & Mergeable, SP: Codable, 
         }
         if meta.tags != nil {
             routeMetaTags(tags: meta.tags!)
+        }
+        if meta.cred != nil {
+            routeMetaCred(cred: meta.cred!)
         }
         // update listener
         listener?.onMeta(meta: meta)

--- a/TinodeSDK/Topic.swift
+++ b/TinodeSDK/Topic.swift
@@ -745,12 +745,7 @@ open class Topic<DP: Codable & Mergeable, DR: Codable & Mergeable, SP: Codable, 
         self.update(tags: tags)
         listener?.onMetaTags(tags: tags)
     }
-    internal func routeMetaCred(cred: [Credential]) {
-        // Do nothing. All processing is in MeTopic in an overridden method.
-    }
-    internal func routeMetaCred(cred: Credential) {
-        // Do nothing. All processing is in MeTopic in an overridden method.
-    }
+
     public func routeMeta(meta: MsgServerMeta) {
         if meta.desc != nil {
             routeMetaDesc(meta: meta)
@@ -766,9 +761,6 @@ open class Topic<DP: Codable & Mergeable, DR: Codable & Mergeable, SP: Codable, 
         }
         if meta.tags != nil {
             routeMetaTags(tags: meta.tags!)
-        }
-        if meta.cred != nil {
-            routeMetaCred(cred: meta.cred!)
         }
         // update listener
         listener?.onMeta(meta: meta)

--- a/TinodeSDK/model/ClientMessages.swift
+++ b/TinodeSDK/model/ClientMessages.swift
@@ -28,7 +28,7 @@ public class MsgClientHi : Encodable {
     }
 }
 
-public class Credential: Codable, Equatable, CustomStringConvertible {
+public class Credential: Codable, Comparable, CustomStringConvertible {
     public static let kMethEmail = "email"
     public static let kMethPhone = "tel"
     // Confirmation method: email, phone, captcha.
@@ -64,8 +64,12 @@ public class Credential: Codable, Equatable, CustomStringConvertible {
         return lhs.meth == rhs.meth && lhs.val == rhs.val
     }
 
+    public static func < (lhs: Credential, rhs: Credential) -> Bool {
+        "\(lhs.meth ?? "-"):\(lhs.val ?? "-"):\(rhs.done ?? false)" < "\(rhs.meth ?? "-"):\(rhs.val ?? "-"):\(rhs.done ?? false)"
+    }
+
     public var description: String {
-        get { return "\(meth ?? "null"):\(val ?? "null")" }
+        get { return "\(meth ?? "-"):\(val ?? "-")" }
     }
 }
 

--- a/TinodeSDK/model/ClientMessages.swift
+++ b/TinodeSDK/model/ClientMessages.swift
@@ -54,7 +54,7 @@ public class Credential: Codable, Equatable, CustomStringConvertible {
         self.params = params
     }
 
-    var isDone: Bool {
+    public var isDone: Bool {
         get {
             return done ?? false
         }
@@ -441,8 +441,9 @@ public class MsgClientDel: Encodable {
     let delseq: [MsgRange]?
     let user: String?
     let hard: Bool?
+    let cred: Credential?
 
-    init(id: String?, topic: String?, what: String?, ranges: [MsgRange]?, user: String?, hard: Bool?) {
+    init(id: String?, topic: String?, what: String?, ranges: [MsgRange]?, user: String?, cred: Credential?, hard: Bool?) {
         self.id = id
         self.topic = topic
         self.what = what
@@ -451,44 +452,45 @@ public class MsgClientDel: Encodable {
         self.delseq = what == MsgClientDel.kStrMsg ? ranges : nil
         self.user = what == MsgClientDel.kStrSub ? user : nil
         self.hard = (hard ?? false) ? true : nil
+        self.cred = cred
     }
 
-    /// Delete messages by list
+    /// Delete multiple message ranges.
     convenience init(id: String?, topic: String, ranges: [MsgRange]?, hard: Bool?) {
         self.init(id: id, topic: topic, what: MsgClientDel.kStrMsg,
                   ranges: ranges,
-                  user: nil, hard: hard)
+                  user: nil, cred: nil, hard: hard)
     }
-    /// Delete messages by range
+    /// Delete range of messages.
     convenience init(id: String?, topic: String, from: Int, to: Int?, hard: Bool?) {
         self.init(id: id, topic: topic, what: MsgClientDel.kStrMsg,
                   ranges: [MsgRange(low: from, hi: to)],
-                  user: nil, hard: hard)
+                  user: nil, cred: nil, hard: hard)
     }
 
     /// Delete message by id
     convenience init(id: String?, topic: String, msgId: Int, hard: Bool?) {
         self.init(id: id, topic: topic, what: MsgClientDel.kStrMsg,
                   ranges: [MsgRange(id: msgId)],
-                  user: nil, hard: hard)
+                  user: nil, cred: nil, hard: hard)
     }
 
     /// Delete topic
     convenience init(id: String?, topic: String) {
         self.init(id: id, topic: topic, what: MsgClientDel.kStrTopic,
-                  ranges: nil, user: nil, hard: nil)
+                  ranges: nil, user: nil, cred: nil, hard: nil)
     }
 
     /// Delete subscription
     convenience init(id: String?, topic: String, user: String?) {
         self.init(id: id, topic: topic, what: MsgClientDel.kStrSub,
-                  ranges: nil, user: user, hard: false)
+                  ranges: nil, user: user, cred: nil, hard: false)
     }
 
     /// Delete credential
     convenience init(id: String?, cred: Credential) {
         self.init(id: id, topic: Tinode.kTopicMe, what: MsgClientDel.kStrCred,
-                  ranges: nil, user: nil, hard: nil)
+                  ranges: nil, user: nil, cred: cred, hard: nil)
     }
 
 }

--- a/TinodeSDK/model/ClientMessages.swift
+++ b/TinodeSDK/model/ClientMessages.swift
@@ -32,9 +32,9 @@ public class Credential: Codable, Equatable, CustomStringConvertible {
     public static let kMethEmail = "email"
     public static let kMethPhone = "tel"
     // Confirmation method: email, phone, captcha.
-    var meth: String? = nil
+    public var meth: String? = nil
     // Credential to be confirmed, e.g. email or a phone number.
-    var val: String? = nil
+    public var val: String? = nil
     // Confirmation response, such as '123456'.
     var resp: String? = nil
     // Confirmation parameters.

--- a/TinodeSDK/model/Drafty.swift
+++ b/TinodeSDK/model/Drafty.swift
@@ -776,9 +776,20 @@ open class Drafty: Codable, CustomStringConvertible, Equatable {
         }
 
         var spans: [Span] = []
+        let maxIndex = txt.count
         for aFmt in fmt! {
-            aFmt.len = max(aFmt.len, 0)
-            aFmt.at = max(aFmt.at, -1)
+            if aFmt.len < 0 {
+                // Invalid length
+                continue
+            }
+            if aFmt.at < 0 {
+                // Attachment
+                aFmt.at = -1
+                aFmt.len = 1
+            } else if (aFmt.at + aFmt.len >= maxIndex) {
+                // Out of bounds span.
+                continue
+            }
             if aFmt.tp == nil || aFmt.tp!.isEmpty {
                 spans.append(Span(start: aFmt.at, end: aFmt.at + aFmt.len, index: aFmt.key ?? 0))
             } else {

--- a/TinodeSDK/model/ServerMessages.swift
+++ b/TinodeSDK/model/ServerMessages.swift
@@ -73,9 +73,10 @@ public class MsgServerMeta: Decodable {
     public let sub: [SubscriptionProto]?
     public let del: DelValues?
     public let tags: [String]?
+    public let cred: [Credential]?
 
     private enum CodingKeys: String, CodingKey  {
-        case id, topic, ts, desc, sub, del, tags
+        case id, topic, ts, desc, sub, del, tags, cred
     }
     required public init (from decoder: Decoder) throws {
         let container =  try decoder.container (keyedBy: CodingKeys.self)
@@ -84,6 +85,7 @@ public class MsgServerMeta: Decodable {
         ts = try? container.decode(Date.self, forKey: .ts)
         del = try? container.decode(DelValues.self, forKey: .del)
         tags = try? container.decode(Array<String>.self, forKey: .tags)
+        cred = try? container.decode(Array<Credential>.self, forKey: .cred)
         if topic == Tinode.kTopicMe {
             desc = try? container.decode(DefaultDescription.self, forKey: .desc)
             sub = try? container.decode(Array<DefaultSubscription>.self, forKey: .sub)

--- a/Tinodios/AccountSettingsViewController.swift
+++ b/Tinodios/AccountSettingsViewController.swift
@@ -275,6 +275,10 @@ class AccountSettingsViewController: UITableViewController {
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: {
                             self?.tableView.reloadRows(at: [indexPath], with: .automatic)
                         })
+                        DispatchQueue.main.async {
+                            UiUtils.showToast(message: "Confirmed successfully", level: .info)
+                            self?.reloadData()
+                        }
                         return nil
                     }
                     .thenCatch(UiUtils.ToastFailureHandler)
@@ -491,7 +495,7 @@ extension AccountSettingsViewController {
 
         guard let cred = me.creds?[indexPath.row - 1], !cred.isDone, cred.meth != nil else { return }
 
-        confirmCredentialClicked(meth: cred.meth!)
+        confirmCredentialClicked(meth: cred.meth!, at: indexPath)
     }
 
     // Enable swipe to delete credentials.

--- a/Tinodios/AccountSettingsViewController.swift
+++ b/Tinodios/AccountSettingsViewController.swift
@@ -178,32 +178,27 @@ class AccountSettingsViewController: UITableViewController {
             return
         }
         UiUtils.showPermissionsEditDialog(over: self, acs: acsUnwrapped, callback: { permissions in
-            _ = try? UiUtils.handlePermissionsChange(onTopic: self.me, forUid: nil, changeType: changeType, newPermissions: permissions)?.then(
+            UiUtils.handlePermissionsChange(onTopic: self.me, forUid: nil, changeType: changeType, newPermissions: permissions)?.then(
                 onSuccess: { msg in
                     DispatchQueue.main.async { self.reloadData() }
                         return nil
-                    }
+                }
             )
         }, disabledPermissions: "ODS")
     }
 
     @IBAction func incognitoModeClicked(_ sender: Any) {
         let isChecked = incognitoModeSwitch.isOn
-        do {
-            try self.me.updateMuted(muted: isChecked)?.then(
-                onSuccess: UiUtils.ToastSuccessHandler,
-                onFailure: { err in
-                    self.incognitoModeSwitch.isOn = !isChecked
-                    return nil
-                }).thenFinally(finally: {
-                    DispatchQueue.main.async { self.reloadData() }
-                })
-        } catch TinodeError.notConnected(_) {
-            incognitoModeSwitch.isOn = !isChecked
-            UiUtils.showToast(message: "You are offline.")
-        } catch {
-            incognitoModeSwitch.isOn = !isChecked
-        }
+        self.me.updateMuted(muted: isChecked)?.then(
+            onSuccess: UiUtils.ToastSuccessHandler,
+            onFailure: { err in
+                self.incognitoModeSwitch.isOn = !isChecked
+                UiUtils.showToast(message: "You are offline.")
+                return nil
+            }).thenFinally(finally: {
+                DispatchQueue.main.async { self.reloadData() }
+            }
+        )
     }
     
     @IBAction func readReceiptsClicked(_ sender: Any) {
@@ -240,14 +235,7 @@ class AccountSettingsViewController: UITableViewController {
                         credMsg = nil
                     }
                     if let credential = credMsg {
-                        do {
-                            try self.me.setMeta(
-                                meta: MsgSetMeta(desc: nil, sub: nil, tags: nil, cred: credential))?.thenCatch(onFailure: UiUtils.ToastFailureHandler)
-                        } catch {
-                            DispatchQueue.main.async {
-                                UiUtils.showToast(message: "Failed to add credential \(error.localizedDescription)")
-                            }
-                        }
+                        self.me.setMeta(meta: MsgSetMeta(desc: nil, sub: nil, tags: nil, cred: credential))?.thenCatch(onFailure: UiUtils.ToastFailureHandler)
                     }
                 }
         }))
@@ -347,7 +335,7 @@ class AccountSettingsViewController: UITableViewController {
             }
             return
         }
-        _ = try? tinode.updateAccountBasic(uid: nil, username: userName, password: newPassword)?.then(
+        tinode.updateAccountBasic(uid: nil, username: userName, password: newPassword)?.then(
             onSuccess: nil,
             onFailure: { err in
                 DispatchQueue.main.async {
@@ -363,7 +351,7 @@ class AccountSettingsViewController: UITableViewController {
         if pub.fn != newTitle {
             pub.fn = String(newTitle.prefix(UiUtils.kMaxTitleLength))
         }
-        _ = try? UiUtils.setTopicData(forTopic: self.me, pub: pub, priv: nil)?.then(
+        UiUtils.setTopicData(forTopic: self.me, pub: pub, priv: nil)?.then(
             onSuccess: { msg in
                 DispatchQueue.main.async { self.reloadData() }
                 return nil
@@ -384,7 +372,7 @@ extension AccountSettingsViewController: ImagePickerDelegate {
             Cache.log.debug("AccountSettingsVC - No image specified or failed to resize, skipping")
             return
         }
-        _ = try? UiUtils.updateAvatar(forTopic: self.me, image: image)?.then(
+        UiUtils.updateAvatar(forTopic: self.me, image: image)?.then(
             onSuccess: { msg in
                 DispatchQueue.main.async {
                     self.reloadData()

--- a/Tinodios/AddByIDViewController.swift
+++ b/Tinodios/AddByIDViewController.swift
@@ -53,7 +53,7 @@ class AddByIDViewController: UIViewController {
         // The description is discarded and re-requested as a part of the subsequent {sub} call.
         // Either get rid of the {get} call or save the returned description.
         let getMeta = MsgGetMeta(desc: MetaGetDesc(), sub: nil, data: nil, del: nil, tags: false, cred: false)
-        tinode.getMeta(topic: id, query: getMeta)?.then(
+        tinode.getMeta(topic: id, query: getMeta).then(
             onSuccess: { [weak self] msg in
                 // Valid topic id.
                 if let desc = msg?.meta?.desc as? Description<VCard, PrivateType> {

--- a/Tinodios/AddByIDViewController.swift
+++ b/Tinodios/AddByIDViewController.swift
@@ -52,7 +52,7 @@ class AddByIDViewController: UIViewController {
         // FIXME: this generates an unnecessary network call which fetches topic description.
         // The description is discarded and re-requested as a part of the subsequent {sub} call.
         // Either get rid of the {get} call or save the returned description.
-        let getMeta = MsgGetMeta(desc: MetaGetDesc(), sub: nil, data: nil, del: nil, tags: false)
+        let getMeta = MsgGetMeta(desc: MetaGetDesc(), sub: nil, data: nil, del: nil, tags: false, cred: false)
         _ = try? tinode.getMeta(topic: id, query: getMeta)?.then(
             onSuccess: { [weak self] msg in
                 // Valid topic id.
@@ -72,7 +72,7 @@ class AddByIDViewController: UIViewController {
                     }
                 }
                 return nil
-            })?.thenFinally(finally: { [weak self] in
+            }).thenFinally(finally: { [weak self] in
                 DispatchQueue.main.async {
                     self?.okayButton.isEnabled = true
                 }

--- a/Tinodios/AddByIDViewController.swift
+++ b/Tinodios/AddByIDViewController.swift
@@ -71,7 +71,7 @@ class AddByIDViewController: UIViewController {
                     }
                 }
                 return nil
-            }).thenFinally(finally: { [weak self] in
+            }).thenFinally({ [weak self] in
                 DispatchQueue.main.async {
                     self?.okayButton.isEnabled = true
                 }

--- a/Tinodios/AddByIDViewController.swift
+++ b/Tinodios/AddByIDViewController.swift
@@ -53,7 +53,7 @@ class AddByIDViewController: UIViewController {
         // The description is discarded and re-requested as a part of the subsequent {sub} call.
         // Either get rid of the {get} call or save the returned description.
         let getMeta = MsgGetMeta(desc: MetaGetDesc(), sub: nil, data: nil, del: nil, tags: false, cred: false)
-        _ = try? tinode.getMeta(topic: id, query: getMeta)?.then(
+        tinode.getMeta(topic: id, query: getMeta)?.then(
             onSuccess: { [weak self] msg in
                 // Valid topic id.
                 if let desc = msg?.meta?.desc as? Description<VCard, PrivateType> {
@@ -63,7 +63,6 @@ class AddByIDViewController: UIViewController {
                 return nil
             },
             onFailure: { err in
-                print("err = \(err)")
                 if let e = err as? TinodeError {
                     if case TinodeError.serverResponseError(let code, let text, _) = e {
                         DispatchQueue.main.async {

--- a/Tinodios/AppDelegate.swift
+++ b/Tinodios/AppDelegate.swift
@@ -95,7 +95,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         var builder: DefaultComTopic.MetaGetBuilder
         if !tinode.isTopicTracked(topicName: topicName) {
             // New topic. Create it.
-            guard let t = tinode.newTopic(for: topicName, with: nil) as? DefaultComTopic else {
+            guard let t = tinode.newTopic(for: topicName) as? DefaultComTopic else {
                 return .failed
             }
             topic = t
@@ -115,12 +115,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 topic.leave()
             }
         }
-        if let msg = try? topic.subscribe(
-            set: nil,
-            get: builder
-                .withLaterData(limit: 10)
-                .withDel().build(),
-            background: true)?.getResult(), (msg.ctrl?.code ?? 500) < 300 {
+        if let msg = try? topic.subscribe(set: nil, get: builder.withLaterData(limit: 10).withDel().build(), background: true).getResult(), (msg.ctrl?.code ?? 500) < 300 {
             return .newData
         }
         return .failed
@@ -139,7 +134,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             return .noData
         }
         do {
-            if let msg = try tinode.getMeta(topic: topicName, query: MsgGetMeta.desc())?.getResult(),
+            if let msg = try tinode.getMeta(topic: topicName, query: MsgGetMeta.desc()).getResult(),
                 (msg.ctrl?.code ?? 500) < 300 {
                 return .newData
             }

--- a/Tinodios/ArchivedChatsTableViewController.swift
+++ b/Tinodios/ArchivedChatsTableViewController.swift
@@ -45,27 +45,24 @@ class ArchivedChatsTableViewController: UITableViewController {
         return cell
     }
     private func unarchiveTopic(topic: DefaultComTopic) {
-        do {
-            try topic.updateArchived(archived: false)?.then(
-                onSuccess: { [weak self] msg in
-                    DispatchQueue.main.async {
-                        if let vc = self {
-                            vc.reloadData()
-                            vc.tableView.reloadData()
-                            // If there are no more archived topics, close the view.
-                            if vc.topics.isEmpty {
-                                vc.navigationController?.popViewController(animated: true)
-                                vc.dismiss(animated: true, completion: nil)
-                            }
+        topic.updateArchived(archived: false)?.then(
+            onSuccess: { [weak self] msg in
+                DispatchQueue.main.async {
+                    if let vc = self {
+                        vc.reloadData()
+                        vc.tableView.reloadData()
+                        // If there are no more archived topics, close the view.
+                        if vc.topics.isEmpty {
+                            vc.navigationController?.popViewController(animated: true)
+                            vc.dismiss(animated: true, completion: nil)
                         }
                     }
-                    return nil
-                },
-                onFailure: UiUtils.ToastFailureHandler)
-        } catch {
-            UiUtils.showToast(message: "Failed to unarchive topic: \(error)")
-        }
+                }
+                return nil
+            },
+            onFailure: UiUtils.ToastFailureHandler)
     }
+
     override func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
         let unarchive = UITableViewRowAction(style: .normal, title: "Unarchive") { (action, indexPath) in
             let topic = self.topics[indexPath.row]

--- a/Tinodios/Base.lproj/Main.storyboard
+++ b/Tinodios/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="oPa-Qr-HlP">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="oPa-Qr-HlP">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -336,7 +336,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Login" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="nho-5Y-Mt8">
-                                                    <rect key="frame" x="16" y="14" width="343" height="22"/>
+                                                    <rect key="frame" x="16" y="13.5" width="343" height="23"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                                     <textInputTraits key="textInputTraits" textContentType="username"/>
                                                 </textField>
@@ -404,7 +404,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="First and last name" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="yKx-xt-rdn">
-                                                    <rect key="frame" x="16" y="14" width="343" height="22"/>
+                                                    <rect key="frame" x="16" y="13.5" width="343" height="23"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                                     <textInputTraits key="textInputTraits" textContentType="name"/>
                                                 </textField>
@@ -424,7 +424,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Email or phone number" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="zmL-3Y-R2r">
-                                                    <rect key="frame" x="16" y="14" width="343" height="22"/>
+                                                    <rect key="frame" x="16" y="13.5" width="343" height="23"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                                     <textInputTraits key="textInputTraits"/>
                                                 </textField>
@@ -695,24 +695,31 @@
                             </tableViewSection>
                             <tableViewSection headerTitle="Tags (Content Discovery)" id="jal-tR-OpF">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" focusStyle="custom" textLabel="eHa-mE-ZbY" imageView="iGu-Eb-fCF" style="IBUITableViewCellStyleDefault" id="Nl1-fA-AeA">
-                                        <rect key="frame" x="0.0" y="415.5" width="375" height="44"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" focusStyle="custom" textLabel="eHa-mE-ZbY" detailTextLabel="K7L-Uc-b68" imageView="iGu-Eb-fCF" style="IBUITableViewCellStyleSubtitle" id="Nl1-fA-AeA">
+                                        <rect key="frame" x="0.0" y="415.5" width="375" height="56"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Nl1-fA-AeA" id="SiW-3F-rOw">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="348" height="56"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Manage" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="eHa-mE-ZbY">
-                                                    <rect key="frame" x="55" y="0.0" width="285" height="44"/>
+                                                    <rect key="frame" x="55" y="9" width="61.5" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" image="tags-24" id="iGu-Eb-fCF">
-                                                    <rect key="frame" x="16" y="10" width="24" height="24"/>
+                                                    <rect key="frame" x="16" y="16" width="24" height="24"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                 </imageView>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="K7L-Uc-b68">
+                                                    <rect key="frame" x="55" y="31.5" width="44" height="14.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
                                             </subviews>
                                         </tableViewCellContentView>
                                         <color key="tintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -722,7 +729,7 @@
                             <tableViewSection headerTitle="Contacts" id="bvE-OV-sy1">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" focusStyle="custom" textLabel="fLh-oI-CRP" imageView="6z9-5Y-HKA" style="IBUITableViewCellStyleDefault" id="WNR-81-Xt2">
-                                        <rect key="frame" x="0.0" y="498.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="510.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="WNR-81-Xt2" id="Ovf-BC-JGG">
                                             <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
@@ -748,7 +755,7 @@
                             <tableViewSection headerTitle="Actions" id="raq-d6-2nI" userLabel="Actions">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" focusStyle="custom" textLabel="qvs-D4-f94" imageView="yia-dl-TYs" style="IBUITableViewCellStyleDefault" id="wqh-Iw-MIx">
-                                        <rect key="frame" x="0.0" y="581.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="593.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="wqh-Iw-MIx" id="3BA-tg-eWe">
                                             <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
@@ -771,7 +778,7 @@
                                         <color key="tintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" focusStyle="custom" textLabel="8RW-nB-5t3" imageView="MiG-tt-8oB" style="IBUITableViewCellStyleDefault" id="bX9-hY-HLX">
-                                        <rect key="frame" x="0.0" y="625.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="637.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="bX9-hY-HLX" id="pBh-TH-7Ln">
                                             <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
@@ -797,21 +804,21 @@
                             <tableViewSection headerTitle="Default Permissions" id="H78-sG-L0j">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="wd7-ah-oJu" detailTextLabel="Un9-ds-iQd" style="IBUITableViewCellStyleValue1" id="Uu3-eu-2fB">
-                                        <rect key="frame" x="0.0" y="708.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="720.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Uu3-eu-2fB" id="XM7-7Y-9qN">
-                                            <rect key="frame" x="0.0" y="0.0" width="356" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Authenticated users" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="wd7-ah-oJu">
-                                                    <rect key="frame" x="15" y="12" width="153.5" height="20.5"/>
+                                                    <rect key="frame" x="16" y="12" width="153.5" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="N" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Un9-ds-iQd">
-                                                    <rect key="frame" x="337.5" y="14" width="10.5" height="19.5"/>
+                                                    <rect key="frame" x="329.5" y="14" width="10.5" height="19.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="CourierNewPSMT" family="Courier New" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -821,21 +828,21 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="8wo-Rg-iTZ" detailTextLabel="bZv-2Q-BI9" style="IBUITableViewCellStyleValue1" id="OkX-G2-xm9">
-                                        <rect key="frame" x="0.0" y="752.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="764.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="OkX-G2-xm9" id="nDD-Lz-qSx">
-                                            <rect key="frame" x="0.0" y="0.0" width="356" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Anonymous users" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="8wo-Rg-iTZ">
-                                                    <rect key="frame" x="15" y="12" width="137" height="20.5"/>
+                                                    <rect key="frame" x="16" y="12" width="137" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="N" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="bZv-2Q-BI9">
-                                                    <rect key="frame" x="337.5" y="14" width="10.5" height="19.5"/>
+                                                    <rect key="frame" x="329.5" y="14" width="10.5" height="19.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="CourierNewPSMT" family="Courier New" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -849,21 +856,21 @@
                             <tableViewSection headerTitle="General" id="out-KF-2FK">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="9Lj-hp-MkL" imageView="TNg-4p-wCN" style="IBUITableViewCellStyleDefault" id="xAE-zC-NgY">
-                                        <rect key="frame" x="0.0" y="835.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="847.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="xAE-zC-NgY" id="Kkg-nH-8W3">
-                                            <rect key="frame" x="0.0" y="0.0" width="356" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Contact us" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="9Lj-hp-MkL">
-                                                    <rect key="frame" x="48" y="0.0" width="300" height="44"/>
+                                                    <rect key="frame" x="56" y="0.0" width="284" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFit" insetsLayoutMarginsFromSafeArea="NO" image="email-25" id="TNg-4p-wCN">
-                                                    <rect key="frame" x="8" y="9.5" width="25" height="25"/>
+                                                    <rect key="frame" x="16" y="9.5" width="25" height="25"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                 </imageView>
                                             </subviews>
@@ -871,21 +878,21 @@
                                         <color key="tintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="9dk-JW-5z0" imageView="JbM-aa-yFe" style="IBUITableViewCellStyleDefault" id="OvL-1Y-CP4">
-                                        <rect key="frame" x="0.0" y="879.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="891.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="OvL-1Y-CP4" id="Ula-EI-Sa8">
-                                            <rect key="frame" x="0.0" y="0.0" width="356" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Terms of use" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="9dk-JW-5z0">
-                                                    <rect key="frame" x="48" y="0.0" width="300" height="44"/>
+                                                    <rect key="frame" x="56" y="0.0" width="284" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFit" insetsLayoutMarginsFromSafeArea="NO" image="contract-25" id="JbM-aa-yFe">
-                                                    <rect key="frame" x="8" y="9.5" width="25" height="25"/>
+                                                    <rect key="frame" x="16" y="9.5" width="25" height="25"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                 </imageView>
                                             </subviews>
@@ -893,21 +900,21 @@
                                         <color key="tintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="Zn8-7V-BcX" imageView="N8i-7L-4Xr" style="IBUITableViewCellStyleDefault" id="vYu-dw-9yV">
-                                        <rect key="frame" x="0.0" y="923.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="935.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="vYu-dw-9yV" id="q5x-UW-aYS">
-                                            <rect key="frame" x="0.0" y="0.0" width="356" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Privacy policy" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Zn8-7V-BcX">
-                                                    <rect key="frame" x="48" y="0.0" width="300" height="44"/>
+                                                    <rect key="frame" x="56" y="0.0" width="284" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFit" insetsLayoutMarginsFromSafeArea="NO" image="shield-25" id="N8i-7L-4Xr">
-                                                    <rect key="frame" x="8" y="9.5" width="25" height="25"/>
+                                                    <rect key="frame" x="16" y="9.5" width="25" height="25"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                 </imageView>
                                             </subviews>
@@ -915,21 +922,21 @@
                                         <color key="tintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="AXP-O2-x5k" detailTextLabel="71p-KF-hSv" style="IBUITableViewCellStyleValue1" id="7Rr-bI-bPv">
-                                        <rect key="frame" x="0.0" y="967.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="979.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="7Rr-bI-bPv" id="Vmv-Vs-Qd9">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="App Version" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="AXP-O2-x5k">
-                                                    <rect key="frame" x="15" y="12" width="92.5" height="20.5"/>
+                                                    <rect key="frame" x="16" y="12" width="92.5" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="1.0.0 (222)" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="71p-KF-hSv">
-                                                    <rect key="frame" x="254.5" y="14" width="112.5" height="19.5"/>
+                                                    <rect key="frame" x="246.5" y="14" width="112.5" height="19.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="CourierNewPSMT" family="Courier New" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -1479,14 +1486,14 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Delete Messages" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="7EV-I9-csz">
-                                                    <rect key="frame" x="54" y="0.0" width="286" height="44"/>
+                                                    <rect key="frame" x="53.5" y="0.0" width="286.5" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" image="delete-message-22" id="s7O-Ko-toQ">
-                                                    <rect key="frame" x="16" y="10.5" width="23" height="23"/>
+                                                    <rect key="frame" x="16" y="10.5" width="22.5" height="22.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                 </imageView>
                                             </subviews>
@@ -1545,14 +1552,14 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Delete Group" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="z6C-JF-Mnb">
-                                                    <rect key="frame" x="54" y="0.0" width="286" height="44"/>
+                                                    <rect key="frame" x="53.5" y="0.0" width="286.5" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" image="delete-bin-22" id="Fj9-Ah-gZk">
-                                                    <rect key="frame" x="16" y="10.5" width="23" height="23"/>
+                                                    <rect key="frame" x="16" y="10.5" width="22.5" height="22.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                 </imageView>
                                             </subviews>
@@ -2175,7 +2182,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Name of the group" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="kDN-bf-JDL">
-                                                    <rect key="frame" x="20" y="14" width="335" height="22"/>
+                                                    <rect key="frame" x="20" y="13.5" width="335" height="23"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                                     <textInputTraits key="textInputTraits"/>
                                                 </textField>
@@ -2195,7 +2202,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Additional info (private)" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Do2-Ue-UdA">
-                                                    <rect key="frame" x="20" y="14" width="335" height="22"/>
+                                                    <rect key="frame" x="20" y="13.5" width="335" height="23"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                                     <textInputTraits key="textInputTraits"/>
                                                 </textField>
@@ -2364,6 +2371,10 @@
             <point key="canvasLocation" x="2971" y="878"/>
         </scene>
     </scenes>
+    <inferredMetricsTieBreakers>
+        <segue reference="qx3-Cj-zCP"/>
+        <segue reference="Fnn-wi-PrS"/>
+    </inferredMetricsTieBreakers>
     <resources>
         <image name="add-25" width="25" height="25"/>
         <image name="arrow-up-48" width="36" height="36"/>
@@ -2387,8 +2398,4 @@
         <image name="sign-out-25" width="25" height="25"/>
         <image name="tags-24" width="24" height="24"/>
     </resources>
-    <inferredMetricsTieBreakers>
-        <segue reference="qx3-Cj-zCP"/>
-        <segue reference="Fnn-wi-PrS"/>
-    </inferredMetricsTieBreakers>
 </document>

--- a/Tinodios/Base.lproj/Main.storyboard
+++ b/Tinodios/Base.lproj/Main.storyboard
@@ -203,14 +203,14 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Request reset code by email or phone" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ykj-eb-phs">
-                                <rect key="frame" x="48" y="112" width="289.5" height="20.5"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Get reset code by email or phone" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ykj-eb-phs">
+                                <rect key="frame" x="48" y="112" width="279" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="VJ5-b7-ozY" userLabel="Email or phone">
-                                <rect key="frame" x="48" y="140.5" width="279" height="40"/>
+                                <rect key="frame" x="48" y="141" width="279" height="40"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="h4Y-dG-mwN"/>
                                 </constraints>
@@ -221,7 +221,7 @@
                                 </connections>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="i0f-S8-O1v">
-                                <rect key="frame" x="150" y="200.5" width="75" height="36"/>
+                                <rect key="frame" x="150" y="201" width="75" height="36"/>
                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="20"/>
                                 <state key="normal" title="Request"/>
                                 <connections>
@@ -237,6 +237,7 @@
                             <constraint firstItem="VJ5-b7-ozY" firstAttribute="leading" secondItem="5k0-8Y-zwM" secondAttribute="leading" constant="48" id="SWU-JT-Ktf"/>
                             <constraint firstItem="5k0-8Y-zwM" firstAttribute="trailing" secondItem="VJ5-b7-ozY" secondAttribute="trailing" constant="48" id="a8g-nJ-fPb"/>
                             <constraint firstItem="Ykj-eb-phs" firstAttribute="top" secondItem="5k0-8Y-zwM" secondAttribute="top" constant="68" id="ert-EH-7bH"/>
+                            <constraint firstItem="VJ5-b7-ozY" firstAttribute="trailing" secondItem="Ykj-eb-phs" secondAttribute="trailing" id="jBT-ZL-9aB"/>
                             <constraint firstItem="VJ5-b7-ozY" firstAttribute="top" secondItem="Ykj-eb-phs" secondAttribute="bottom" constant="8" symbolic="YES" id="jgf-Cn-fzh"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="5k0-8Y-zwM"/>
@@ -604,7 +605,7 @@
                             </tableViewSection>
                             <tableViewSection headerTitle="Notifications" id="3gX-G0-wiF">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="WUa-h4-3PP">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="WUa-h4-3PP">
                                         <rect key="frame" x="0.0" y="244.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="WUa-h4-3PP" id="RrA-Cz-gSZ">
@@ -807,18 +808,18 @@
                                         <rect key="frame" x="0.0" y="720.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Uu3-eu-2fB" id="XM7-7Y-9qN">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="356" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Authenticated users" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="wd7-ah-oJu">
-                                                    <rect key="frame" x="16" y="12" width="153.5" height="20.5"/>
+                                                    <rect key="frame" x="15" y="12" width="153.5" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="N" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Un9-ds-iQd">
-                                                    <rect key="frame" x="329.5" y="14" width="10.5" height="19.5"/>
+                                                    <rect key="frame" x="337.5" y="14" width="10.5" height="19.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="CourierNewPSMT" family="Courier New" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -831,18 +832,18 @@
                                         <rect key="frame" x="0.0" y="764.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="OkX-G2-xm9" id="nDD-Lz-qSx">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="356" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Anonymous users" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="8wo-Rg-iTZ">
-                                                    <rect key="frame" x="16" y="12" width="137" height="20.5"/>
+                                                    <rect key="frame" x="15" y="12" width="137" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="N" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="bZv-2Q-BI9">
-                                                    <rect key="frame" x="329.5" y="14" width="10.5" height="19.5"/>
+                                                    <rect key="frame" x="337.5" y="14" width="10.5" height="19.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="CourierNewPSMT" family="Courier New" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -859,18 +860,18 @@
                                         <rect key="frame" x="0.0" y="847.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="xAE-zC-NgY" id="Kkg-nH-8W3">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="356" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Contact us" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="9Lj-hp-MkL">
-                                                    <rect key="frame" x="56" y="0.0" width="284" height="44"/>
+                                                    <rect key="frame" x="48" y="0.0" width="300" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFit" insetsLayoutMarginsFromSafeArea="NO" image="email-25" id="TNg-4p-wCN">
-                                                    <rect key="frame" x="16" y="9.5" width="25" height="25"/>
+                                                    <rect key="frame" x="8" y="9.5" width="25" height="25"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                 </imageView>
                                             </subviews>
@@ -881,18 +882,18 @@
                                         <rect key="frame" x="0.0" y="891.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="OvL-1Y-CP4" id="Ula-EI-Sa8">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="356" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Terms of use" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="9dk-JW-5z0">
-                                                    <rect key="frame" x="56" y="0.0" width="284" height="44"/>
+                                                    <rect key="frame" x="48" y="0.0" width="300" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFit" insetsLayoutMarginsFromSafeArea="NO" image="contract-25" id="JbM-aa-yFe">
-                                                    <rect key="frame" x="16" y="9.5" width="25" height="25"/>
+                                                    <rect key="frame" x="8" y="9.5" width="25" height="25"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                 </imageView>
                                             </subviews>
@@ -903,18 +904,18 @@
                                         <rect key="frame" x="0.0" y="935.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="vYu-dw-9yV" id="q5x-UW-aYS">
-                                            <rect key="frame" x="0.0" y="0.0" width="348" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="356" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Privacy policy" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Zn8-7V-BcX">
-                                                    <rect key="frame" x="56" y="0.0" width="284" height="44"/>
+                                                    <rect key="frame" x="48" y="0.0" width="300" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFit" insetsLayoutMarginsFromSafeArea="NO" image="shield-25" id="N8i-7L-4Xr">
-                                                    <rect key="frame" x="16" y="9.5" width="25" height="25"/>
+                                                    <rect key="frame" x="8" y="9.5" width="25" height="25"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                 </imageView>
                                             </subviews>
@@ -929,14 +930,14 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="App Version" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="AXP-O2-x5k">
-                                                    <rect key="frame" x="16" y="12" width="92.5" height="20.5"/>
+                                                    <rect key="frame" x="15" y="12" width="92.5" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="1.0.0 (222)" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="71p-KF-hSv">
-                                                    <rect key="frame" x="246.5" y="14" width="112.5" height="19.5"/>
+                                                    <rect key="frame" x="254.5" y="14" width="112.5" height="19.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="CourierNewPSMT" family="Courier New" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -1949,12 +1950,12 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="vI0-4K-STN">
-                                <rect key="frame" x="40" y="133.5" width="295" height="34"/>
+                                <rect key="frame" x="40" y="156.5" width="295" height="34"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Confirmation code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JlG-TH-asZ">
-                                <rect key="frame" x="40" y="104" width="142" height="21.5"/>
+                                <rect key="frame" x="40" y="104" width="295" height="44.5"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="JlG-TH-asZ" secondAttribute="height" multiplier="139:21" id="g3s-5S-HsD"/>
                                 </constraints>
@@ -1963,7 +1964,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aFc-MO-QyO">
-                                <rect key="frame" x="151" y="187.5" width="73" height="36"/>
+                                <rect key="frame" x="151" y="210.5" width="73" height="36"/>
                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="20"/>
                                 <state key="normal" title="Confirm"/>
                                 <connections>
@@ -1977,6 +1978,7 @@
                             <constraint firstItem="JlG-TH-asZ" firstAttribute="topMargin" secondItem="wFR-Kb-wCU" secondAttribute="top" constant="68" id="cn5-tU-Ghc"/>
                             <constraint firstItem="wFR-Kb-wCU" firstAttribute="trailing" secondItem="vI0-4K-STN" secondAttribute="trailingMargin" constant="48" id="lOv-J2-nmD"/>
                             <constraint firstItem="vI0-4K-STN" firstAttribute="top" secondItem="JlG-TH-asZ" secondAttribute="bottom" constant="8" symbolic="YES" id="mSR-qS-wGZ"/>
+                            <constraint firstItem="vI0-4K-STN" firstAttribute="trailing" secondItem="JlG-TH-asZ" secondAttribute="trailing" id="qkX-pa-zi4"/>
                             <constraint firstItem="vI0-4K-STN" firstAttribute="leadingMargin" secondItem="wFR-Kb-wCU" secondAttribute="leading" constant="48" id="sFf-hg-f4R"/>
                             <constraint firstItem="JlG-TH-asZ" firstAttribute="leading" secondItem="vI0-4K-STN" secondAttribute="leading" id="zVe-Xk-RDo"/>
                         </constraints>
@@ -2311,7 +2313,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Topic or user ID" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RA0-dx-dSp">
-                                <rect key="frame" x="16" y="112" width="120" height="21"/>
+                                <rect key="frame" x="16" y="112" width="343" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -2331,6 +2333,7 @@
                             </button>
                         </subviews>
                         <constraints>
+                            <constraint firstItem="xmn-wq-Hpr" firstAttribute="trailing" secondItem="RA0-dx-dSp" secondAttribute="trailing" id="8ux-tK-1z8"/>
                             <constraint firstItem="xmn-wq-Hpr" firstAttribute="leading" secondItem="K64-fR-Pcz" secondAttribute="leading" constant="16" id="D9w-ln-g5l"/>
                             <constraint firstItem="RA0-dx-dSp" firstAttribute="top" secondItem="K64-fR-Pcz" secondAttribute="top" constant="16" id="LHU-FR-dtA"/>
                             <constraint firstItem="DMQ-om-04T" firstAttribute="centerX" secondItem="K64-fR-Pcz" secondAttribute="centerX" id="Plb-zp-ivW"/>

--- a/Tinodios/Base.lproj/Main.storyboard
+++ b/Tinodios/Base.lproj/Main.storyboard
@@ -37,10 +37,10 @@
                                 <rect key="frame" x="27.5" y="0.0" width="320" height="522"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="247" axis="vertical" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="mpq-rw-B1Z" userLabel="Content Stack">
-                                        <rect key="frame" x="40" y="16" width="240" height="343"/>
+                                        <rect key="frame" x="30" y="16" width="260" height="343"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Rob-ty-RSP" userLabel="Logo area">
-                                                <rect key="frame" x="0.0" y="0.0" width="240" height="120"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="260" height="120"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" verticalCompressionResistancePriority="749" image="logo-ios" translatesAutoresizingMaskIntoConstraints="NO" id="kjo-LF-vGk">
                                                         <rect key="frame" x="8" y="28" width="64" height="64"/>
@@ -50,7 +50,7 @@
                                                         </constraints>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="752" text="Tinode" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BS4-zj-4bf">
-                                                        <rect key="frame" x="80" y="38" width="140" height="44"/>
+                                                        <rect key="frame" x="80" y="38" width="160" height="44"/>
                                                         <fontDescription key="fontDescription" name="Avenir-Medium" family="Avenir" pointSize="32"/>
                                                         <color key="textColor" red="0.22352941176470587" green="0.28627450980392155" blue="0.6705882352941176" alpha="1" colorSpace="calibratedRGB"/>
                                                         <nil key="highlightedColor"/>
@@ -67,7 +67,7 @@
                                                 </constraints>
                                             </view>
                                             <textField opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" selected="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="User name" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZTD-e7-fNF">
-                                                <rect key="frame" x="0.0" y="123" width="240" height="40"/>
+                                                <rect key="frame" x="0.0" y="123" width="260" height="40"/>
                                                 <accessibility key="accessibilityConfiguration" hint="Login" identifier="usernameText" label="Login">
                                                     <accessibilityTraits key="traits" header="YES"/>
                                                 </accessibility>
@@ -78,10 +78,10 @@
                                                 <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" smartDashesType="no" smartQuotesType="no" textContentType="username"/>
                                             </textField>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vPY-ED-Q8f">
-                                                <rect key="frame" x="0.0" y="166" width="240" height="40"/>
+                                                <rect key="frame" x="0.0" y="166" width="260" height="40"/>
                                                 <subviews>
                                                     <textField opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gLF-JR-ZfF">
-                                                        <rect key="frame" x="0.0" y="0.0" width="240" height="40"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="260" height="40"/>
                                                         <accessibility key="accessibilityConfiguration" hint="Password" identifier="passwordText" label="Password"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="40" id="An3-zR-ZWF"/>
@@ -118,10 +118,10 @@
                                                     </button>
                                                 </subviews>
                                                 <constraints>
-                                                    <constraint firstItem="kUP-kl-SzZ" firstAttribute="trailing" secondItem="gLF-JR-ZfF" secondAttribute="trailing" constant="-10" id="Plt-gh-StO"/>
+                                                    <constraint firstItem="kUP-kl-SzZ" firstAttribute="trailing" secondItem="gLF-JR-ZfF" secondAttribute="trailing" constant="-30" id="Plt-gh-StO"/>
                                                     <constraint firstItem="gLF-JR-ZfF" firstAttribute="width" secondItem="vPY-ED-Q8f" secondAttribute="width" id="Rcp-EQ-hXx"/>
                                                     <constraint firstItem="gLF-JR-ZfF" firstAttribute="centerY" secondItem="vPY-ED-Q8f" secondAttribute="centerY" id="UvP-pD-uwp"/>
-                                                    <constraint firstItem="Qf5-ud-WtI" firstAttribute="trailing" secondItem="gLF-JR-ZfF" secondAttribute="trailing" constant="-10" id="aWN-Wy-e1D"/>
+                                                    <constraint firstItem="Qf5-ud-WtI" firstAttribute="trailing" secondItem="gLF-JR-ZfF" secondAttribute="trailing" constant="-30" id="aWN-Wy-e1D"/>
                                                     <constraint firstItem="gLF-JR-ZfF" firstAttribute="centerX" secondItem="vPY-ED-Q8f" secondAttribute="centerX" id="bum-AF-beD"/>
                                                     <constraint firstItem="kUP-kl-SzZ" firstAttribute="centerY" secondItem="gLF-JR-ZfF" secondAttribute="centerY" id="d9x-qg-V02"/>
                                                     <constraint firstItem="gLF-JR-ZfF" firstAttribute="height" secondItem="vPY-ED-Q8f" secondAttribute="height" id="h73-7U-aiX"/>
@@ -129,7 +129,7 @@
                                                 </constraints>
                                             </view>
                                             <button opaque="NO" contentMode="right" verticalCompressionResistancePriority="751" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q6T-TC-n42">
-                                                <rect key="frame" x="0.0" y="209" width="240" height="32"/>
+                                                <rect key="frame" x="0.0" y="209" width="260" height="32"/>
                                                 <fontDescription key="fontDescription" type="system" weight="light" pointSize="16"/>
                                                 <state key="normal" title="Forgot password?">
                                                     <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -139,7 +139,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TvF-F9-blO">
-                                                <rect key="frame" x="0.0" y="244" width="240" height="36"/>
+                                                <rect key="frame" x="0.0" y="244" width="260" height="36"/>
                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="20"/>
                                                 <state key="normal" title="Sign In"/>
                                                 <connections>
@@ -147,7 +147,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="bottom" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1tv-os-KfJ">
-                                                <rect key="frame" x="0.0" y="283" width="240" height="60"/>
+                                                <rect key="frame" x="0.0" y="283" width="260" height="60"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="60" id="46f-6h-yBT"/>
                                                 </constraints>
@@ -159,18 +159,18 @@
                                             </button>
                                         </subviews>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="240" id="1Uv-h5-EvQ"/>
+                                            <constraint firstAttribute="width" constant="260" id="1Uv-h5-EvQ"/>
                                         </constraints>
                                     </stackView>
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="mpq-rw-B1Z" firstAttribute="centerX" secondItem="7rS-xG-6h7" secondAttribute="centerX" id="D9f-Kx-OJU"/>
-                                    <constraint firstAttribute="trailing" secondItem="mpq-rw-B1Z" secondAttribute="trailing" constant="40" id="DbT-Ev-XnI"/>
+                                    <constraint firstAttribute="trailing" secondItem="mpq-rw-B1Z" secondAttribute="trailing" constant="30" id="DbT-Ev-XnI"/>
                                     <constraint firstAttribute="bottom" secondItem="mpq-rw-B1Z" secondAttribute="bottom" constant="40" id="G7o-Rz-I8A"/>
                                     <constraint firstAttribute="width" constant="320" id="Oys-cW-axq"/>
                                     <constraint firstItem="mpq-rw-B1Z" firstAttribute="top" secondItem="7rS-xG-6h7" secondAttribute="top" constant="16" id="TFv-Mp-ajD"/>
                                     <constraint firstAttribute="height" constant="522" id="WKa-2C-SfL"/>
-                                    <constraint firstItem="mpq-rw-B1Z" firstAttribute="leading" secondItem="7rS-xG-6h7" secondAttribute="leading" constant="40" id="kzS-Si-7D8"/>
+                                    <constraint firstItem="mpq-rw-B1Z" firstAttribute="leading" secondItem="7rS-xG-6h7" secondAttribute="leading" constant="30" id="kzS-Si-7D8"/>
                                 </constraints>
                             </scrollView>
                         </subviews>
@@ -362,7 +362,7 @@
                                                     <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" secureTextEntry="YES" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no" textContentType="password"/>
                                                 </textField>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Lbr-pr-fEn" userLabel="eye">
-                                                    <rect key="frame" x="329" y="15" width="20" height="20"/>
+                                                    <rect key="frame" x="309" y="15" width="20" height="20"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="20" id="CUU-fG-vo8"/>
                                                         <constraint firstAttribute="height" constant="20" id="MUJ-OG-3Y0"/>
@@ -374,7 +374,7 @@
                                                     </connections>
                                                 </button>
                                                 <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wBH-qF-T4u" userLabel="invisible">
-                                                    <rect key="frame" x="329" y="15" width="20" height="20"/>
+                                                    <rect key="frame" x="309" y="15" width="20" height="20"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="20" id="9pa-yU-y4U"/>
                                                         <constraint firstAttribute="width" constant="20" id="CpN-aO-z52"/>
@@ -391,9 +391,9 @@
                                                 <constraint firstItem="wBH-qF-T4u" firstAttribute="centerY" secondItem="ZQy-2N-acy" secondAttribute="centerY" id="8WC-RB-LYA"/>
                                                 <constraint firstItem="ZQy-2N-acy" firstAttribute="leading" secondItem="y4X-ec-onf" secondAttribute="leadingMargin" id="IlJ-NW-XhT"/>
                                                 <constraint firstItem="Lbr-pr-fEn" firstAttribute="centerY" secondItem="ZQy-2N-acy" secondAttribute="centerY" id="Yzg-AM-3Y8"/>
-                                                <constraint firstItem="Lbr-pr-fEn" firstAttribute="trailing" secondItem="ZQy-2N-acy" secondAttribute="trailing" constant="-10" id="pwN-Fl-Saw"/>
+                                                <constraint firstItem="Lbr-pr-fEn" firstAttribute="trailing" secondItem="ZQy-2N-acy" secondAttribute="trailing" constant="-30" id="pwN-Fl-Saw"/>
                                                 <constraint firstAttribute="trailingMargin" secondItem="ZQy-2N-acy" secondAttribute="trailing" id="wNm-iH-3j9"/>
-                                                <constraint firstItem="wBH-qF-T4u" firstAttribute="trailing" secondItem="ZQy-2N-acy" secondAttribute="trailing" constant="-10" id="wiu-WY-Had"/>
+                                                <constraint firstItem="wBH-qF-T4u" firstAttribute="trailing" secondItem="ZQy-2N-acy" secondAttribute="trailing" constant="-30" id="wiu-WY-Had"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>

--- a/Tinodios/ChatListInteractor.swift
+++ b/Tinodios/ChatListInteractor.swift
@@ -152,7 +152,7 @@ class ChatListInteractor: ChatListBusinessLogic, ChatListDataStore {
 
     func deleteTopic(_ name: String) {
         let topic = Cache.getTinode().getTopic(topicName: name) as! DefaultComTopic
-        topic.delete()?.then(
+        topic.delete().then(
             onSuccess: { [weak self] msg in
                 self?.loadAndPresentTopics()
                 return nil

--- a/Tinodios/ChatListInteractor.swift
+++ b/Tinodios/ChatListInteractor.swift
@@ -88,23 +88,20 @@ class ChatListInteractor: ChatListBusinessLogic, ChatListDataStore {
         guard meTopic == nil || !meTopic!.attached else {
             return
         }
-        do {
-            try UiUtils.attachToMeTopic(meListener: self.meListener)?.then(
-                onSuccess: { [weak self] msg in
-                    self?.loadAndPresentTopics()
-                    self?.meTopic = tinode.getMeTopic()
-                    return nil
-                }, onFailure: { [weak self] err in
-                    if let e = err as? TinodeError, case .serverResponseError(let code, _, _) = e {
-                        if code == 404 {
-                            self?.router?.routeToLogin()
-                        }
+
+        UiUtils.attachToMeTopic(meListener: self.meListener)?.then(
+            onSuccess: { [weak self] msg in
+                self?.loadAndPresentTopics()
+                self?.meTopic = tinode.getMeTopic()
+                return nil
+            }, onFailure: { [weak self] err in
+                if let e = err as? TinodeError, case .serverResponseError(let code, _, _) = e {
+                    if code == 401 || code==403 || code == 404 {
+                        self?.router?.routeToLogin()
                     }
-                    return nil
-                })
-        } catch {
-            self.router?.routeToLogin()
-        }
+                }
+                return nil
+            })
     }
     func leaveMeTopic() {
         if self.meTopic?.attached ?? false {
@@ -155,25 +152,29 @@ class ChatListInteractor: ChatListBusinessLogic, ChatListDataStore {
 
     func deleteTopic(_ name: String) {
         let topic = Cache.getTinode().getTopic(topicName: name) as! DefaultComTopic
-        do {
-            try topic.delete()?.then(onSuccess: { [weak self] msg in
+        topic.delete()?.then(
+            onSuccess: { [weak self] msg in
                 self?.loadAndPresentTopics()
                 return nil
-            })
-        } catch {
-            Cache.log.error("ChatListInteractor - Delete op failed for topic: %@", name)
-        }
+            },
+            onFailure: { _ in
+                Cache.log.error("ChatListInteractor - Delete op failed for topic: %@", name)
+                return nil
+            }
+        )
     }
 
     func changeArchivedStatus(forTopic name: String, archived: Bool) {
         let topic = Cache.getTinode().getTopic(topicName: name) as! DefaultComTopic
-        do {
-            try topic.updateArchived(archived: archived)?.then(onSuccess: { [weak self] msg in
+        topic.updateArchived(archived: archived)?.then(
+            onSuccess: { [weak self] msg in
                 self?.loadAndPresentTopics()
+                    return nil
+                },
+            onFailure: { _ in
+                Cache.log.error("ChatListInteractor - Archive/Unarchive op failed for topic: %@", name)
                 return nil
-            })
-        } catch {
-            Cache.log.error("ChatListInteractor - Archive/Unarchive op failed for topic: %@", name)
-        }
+            }
+        )
     }
 }

--- a/Tinodios/CredentialsViewController.swift
+++ b/Tinodios/CredentialsViewController.swift
@@ -56,7 +56,7 @@ class CredentialsViewController : UIViewController {
         var creds = [Credential]()
         creds.append(c)
 
-        tinode.loginToken(token: token, creds: creds)?
+        tinode.loginToken(token: token, creds: creds)
             .thenApply(onSuccess: { msg in
                 if let ctrl = msg?.ctrl, ctrl.code >= 300 {
                     DispatchQueue.main.async {

--- a/Tinodios/CredentialsViewController.swift
+++ b/Tinodios/CredentialsViewController.swift
@@ -57,7 +57,7 @@ class CredentialsViewController : UIViewController {
         creds.append(c)
 
         tinode.loginToken(token: token, creds: creds)
-            .thenApply(onSuccess: { msg in
+            .thenApply({ msg in
                 if let ctrl = msg?.ctrl, ctrl.code >= 300 {
                     DispatchQueue.main.async {
                         UiUtils.showToast(message: "Verification failure: \(ctrl.code) \(ctrl.text)")

--- a/Tinodios/CredentialsViewController.swift
+++ b/Tinodios/CredentialsViewController.swift
@@ -56,23 +56,19 @@ class CredentialsViewController : UIViewController {
         var creds = [Credential]()
         creds.append(c)
 
-        do {
-            try tinode.loginToken(token: token, creds: creds)?
-                .thenApply(onSuccess: { msg in
-                    if let ctrl = msg?.ctrl, ctrl.code >= 300 {
-                        DispatchQueue.main.async {
-                            UiUtils.showToast(message: "Verification failure: \(ctrl.code) \(ctrl.text)")
-                        }
-                    } else {
-                        if let token = tinode.authToken {
-                            tinode.setAutoLoginWithToken(token: token)
-                        }
-                        UiUtils.routeToChatListVC()
+        tinode.loginToken(token: token, creds: creds)?
+            .thenApply(onSuccess: { msg in
+                if let ctrl = msg?.ctrl, ctrl.code >= 300 {
+                    DispatchQueue.main.async {
+                        UiUtils.showToast(message: "Verification failure: \(ctrl.code) \(ctrl.text)")
                     }
-                    return nil
-                })
-        } catch {
-            Cache.log.error("CredentialsVC - loginToken failed: %@", error.localizedDescription)
-        }
+                } else {
+                    if let token = tinode.authToken {
+                        tinode.setAutoLoginWithToken(token: token)
+                    }
+                    UiUtils.routeToChatListVC()
+                }
+                return nil
+            })
     }
 }

--- a/Tinodios/FindInteractor.swift
+++ b/Tinodios/FindInteractor.swift
@@ -122,7 +122,7 @@ class FindInteractor: FindBusinessLogic {
         let tinode = Cache.getTinode()
         var topic: DefaultComTopic?
         if !tinode.isTopicTracked(topicName: topicName) {
-            topic = tinode.newTopic(for: topicName, with: nil) as? DefaultComTopic
+            topic = tinode.newTopic(for: topicName) as? DefaultComTopic
             topic?.pub = sub.pub
             topic?.persist(true)
         } else {

--- a/Tinodios/FindInteractor.swift
+++ b/Tinodios/FindInteractor.swift
@@ -59,19 +59,15 @@ class FindInteractor: FindBusinessLogic {
     }
     func attachToFndTopic() {
         let tinode = Cache.getTinode()
-        do {
-            try UiUtils.attachToFndTopic(
-                fndListener: self.fndListener)?.then(
-                    onSuccess: { [weak self] msg in
-                        self?.fndTopic = tinode.getOrCreateFndTopic()
-                        return nil
-                    },
-                    onFailure: { err in
-                        return nil
-                    })
-        } catch {
-            Cache.log.error("FindInteractor - failed to attach to fnd topic: %@", error.localizedDescription)
-        }
+        UiUtils.attachToFndTopic(fndListener: self.fndListener)?.then(
+                onSuccess: { [weak self] msg in
+                    self?.fndTopic = tinode.getOrCreateFndTopic()
+                    return nil
+                },
+                onFailure: { err in
+                    Cache.log.error("FindInteractor - failed to attach to fnd topic: %@", err.localizedDescription)
+                    return nil
+                })
 
     }
     func updateAndPresentRemoteContacts() {

--- a/Tinodios/LoginViewController.swift
+++ b/Tinodios/LoginViewController.swift
@@ -126,7 +126,7 @@ class LoginViewController: UIViewController {
                 .then(
                     onSuccess: { pkt in
                         return tinode.loginBasic(uname: userName, password: password)
-                    })?
+                    })
                 .then(
                     onSuccess: { [weak self] pkt in
                         Cache.log.info("LoginVC - login successful for %@", tinode.myUid!)
@@ -158,7 +158,7 @@ class LoginViewController: UIViewController {
                         }
                         _ = tinode.logout()
                         return nil
-                    })?.thenFinally { [weak self] in
+                    }).thenFinally { [weak self] in
                         guard let loginVC = self else { return }
                         DispatchQueue.main.async {
                             UiUtils.toggleProgressOverlay(in: loginVC, visible: false)

--- a/Tinodios/LoginViewController.swift
+++ b/Tinodios/LoginViewController.swift
@@ -123,8 +123,7 @@ class LoginViewController: UIViewController {
         UiUtils.toggleProgressOverlay(in: self, visible: true, title: "Logging in...")
         do {
             try tinode.connectDefault()?
-                .then(
-                    onSuccess: { pkt in
+                .thenApply({ pkt in
                         return tinode.loginBasic(uname: userName, password: password)
                     })
                 .then(

--- a/Tinodios/MessageInteractor.swift
+++ b/Tinodios/MessageInteractor.swift
@@ -242,7 +242,7 @@ class MessageInteractor: DefaultComTopic.Listener, MessageBusinessLogic, Message
         if !loadNextPageInternal() && !StoredTopic.isAllDataLoaded(topic: t) {
             t.getMeta(query:t.getMetaGetBuilder()
                 .withEarlierData(limit: MessageInteractor.kMessagesPerPage).build())
-                .thenFinally(finally: { [weak self] in
+                .thenFinally({ [weak self] in
                     self?.presenter?.endRefresh()
                 })
         } else {
@@ -266,7 +266,7 @@ class MessageInteractor: DefaultComTopic.Listener, MessageBusinessLogic, Message
         guard am.given?.update(from: "+RW") ?? false else {
             return
         }
-        topic?.setMeta(meta: MsgSetMeta(desc: nil, sub: MetaSetSub(user: topic?.name, mode: am.givenString), tags: nil, cred: nil)).thenCatch(onFailure: UiUtils.ToastFailureHandler)
+        topic?.setMeta(meta: MsgSetMeta(desc: nil, sub: MetaSetSub(user: topic?.name, mode: am.givenString), tags: nil, cred: nil)).thenCatch(UiUtils.ToastFailureHandler)
     }
 
     func acceptInvitation() {
@@ -287,14 +287,14 @@ class MessageInteractor: DefaultComTopic.Listener, MessageBusinessLogic, Message
                 onFailure: UiUtils.ToastFailureHandler
             )
         }
-        response.thenApply(onSuccess: { msg in
+        response.thenApply({ msg in
             self.presenter?.applyTopicPermissions(withError: nil)
             return nil
         })
     }
     func ignoreInvitation() {
-        self.topic?.delete().thenFinally(
-            finally: {
+        self.topic?.delete()
+            .thenFinally({
                 self.presenter?.dismiss()
             })
     }
@@ -304,11 +304,10 @@ class MessageInteractor: DefaultComTopic.Listener, MessageBusinessLogic, Message
         let am = Acs(from: origAm)
         guard am.want?.update(from: "-JP") ?? false else { return }
         self.topic?.setMeta(meta: MsgSetMeta(desc: nil, sub: MetaSetSub(mode: am.wantString), tags: nil, cred: nil))
-            .thenCatch(onFailure: UiUtils.ToastFailureHandler)
-            .thenFinally(
-                finally: {
-                    self.presenter?.dismiss()
-                })
+            .thenCatch(UiUtils.ToastFailureHandler)
+            .thenFinally({
+                self.presenter?.dismiss()
+            })
     }
 
     static private func existingInteractor(for topicName: String?) -> MessageInteractor? {
@@ -363,9 +362,10 @@ class MessageInteractor: DefaultComTopic.Listener, MessageBusinessLogic, Message
                         mime: mimeType, fname: filename,
                         refurl: srvUrl, size: data.count) {
                         _ = topic.store?.msgReady(topic: topic, dbMessageId: msgId, data: content)
-                        topic.syncOne(msgId: msgId).thenFinally(finally: {
-                            interactor?.loadMessages()
-                        })
+                        topic.syncOne(msgId: msgId)
+                            .thenFinally({
+                                interactor?.loadMessages()
+                            })
                         success = true
                     }
                 })

--- a/Tinodios/MessageInteractor.swift
+++ b/Tinodios/MessageInteractor.swift
@@ -128,10 +128,10 @@ class MessageInteractor: DefaultComTopic.Listener, MessageBusinessLogic, Message
         if topic.isOwner {
             builder = builder.withTags()
         }
-        topic.subscribe(set: nil, get: builder.build())?.then(
+        topic.subscribe(set: nil, get: builder.build()).then(
                 onSuccess: { [weak self] _ in
                     self?.messageInteractorQueue.async {
-                        self?.topic?.syncAll()?.then(
+                        self?.topic?.syncAll().then(
                             onSuccess: { [weak self] _ in
                                 self?.loadMessages()
                                 return nil
@@ -176,7 +176,7 @@ class MessageInteractor: DefaultComTopic.Listener, MessageBusinessLogic, Message
         defer {
             loadMessages()
         }
-        topic.publish(content: content)?.then(
+        topic.publish(content: content).then(
             onSuccess: { [weak self] msg in
                 self?.loadMessages()
                 return nil
@@ -241,7 +241,7 @@ class MessageInteractor: DefaultComTopic.Listener, MessageBusinessLogic, Message
         }
         if !loadNextPageInternal() && !StoredTopic.isAllDataLoaded(topic: t) {
             t.getMeta(query:t.getMetaGetBuilder()
-                .withEarlierData(limit: MessageInteractor.kMessagesPerPage).build())?
+                .withEarlierData(limit: MessageInteractor.kMessagesPerPage).build())
                 .thenFinally(finally: { [weak self] in
                     self?.presenter?.endRefresh()
                 })
@@ -250,7 +250,7 @@ class MessageInteractor: DefaultComTopic.Listener, MessageBusinessLogic, Message
         }
     }
     func deleteMessage(seqId: Int) {
-        topic?.delMessage(id: seqId, hard: false)?.then(
+        topic?.delMessage(id: seqId, hard: false).then(
             onSuccess: { [weak self] msg in
                 self?.loadMessages()
                 return nil
@@ -266,11 +266,7 @@ class MessageInteractor: DefaultComTopic.Listener, MessageBusinessLogic, Message
         guard am.given?.update(from: "+RW") ?? false else {
             return
         }
-        topic?.setMeta(meta: MsgSetMeta(
-            desc: nil,
-            sub: MetaSetSub(user: topic?.name, mode: am.givenString),
-            tags: nil,
-            cred: nil))?.thenCatch(onFailure: UiUtils.ToastFailureHandler)
+        topic?.setMeta(meta: MsgSetMeta(desc: nil, sub: MetaSetSub(user: topic?.name, mode: am.givenString), tags: nil, cred: nil)).thenCatch(onFailure: UiUtils.ToastFailureHandler)
     }
 
     func acceptInvitation() {
@@ -279,7 +275,7 @@ class MessageInteractor: DefaultComTopic.Listener, MessageBusinessLogic, Message
         if topic.isP2PType {
             // For P2P topics change 'given' permission of the peer too.
             // In p2p topics the other user has the same name as the topic.
-            response = response?.then(
+            response = response.then(
                 onSuccess: { msg in
                     _ = topic.setMeta(meta: MsgSetMeta(
                         desc: nil,
@@ -291,13 +287,13 @@ class MessageInteractor: DefaultComTopic.Listener, MessageBusinessLogic, Message
                 onFailure: UiUtils.ToastFailureHandler
             )
         }
-        response?.thenApply(onSuccess: { msg in
+        response.thenApply(onSuccess: { msg in
             self.presenter?.applyTopicPermissions(withError: nil)
             return nil
         })
     }
     func ignoreInvitation() {
-        self.topic?.delete()?.thenFinally(
+        self.topic?.delete().thenFinally(
             finally: {
                 self.presenter?.dismiss()
             })
@@ -307,8 +303,8 @@ class MessageInteractor: DefaultComTopic.Listener, MessageBusinessLogic, Message
         guard let origAm = self.topic?.accessMode else { return }
         let am = Acs(from: origAm)
         guard am.want?.update(from: "-JP") ?? false else { return }
-        self.topic?.setMeta(meta: MsgSetMeta(desc: nil, sub: MetaSetSub(mode: am.wantString), tags: nil, cred: nil))?
-            .thenCatch(onFailure: UiUtils.ToastFailureHandler)?
+        self.topic?.setMeta(meta: MsgSetMeta(desc: nil, sub: MetaSetSub(mode: am.wantString), tags: nil, cred: nil))
+            .thenCatch(onFailure: UiUtils.ToastFailureHandler)
             .thenFinally(
                 finally: {
                     self.presenter?.dismiss()
@@ -367,7 +363,7 @@ class MessageInteractor: DefaultComTopic.Listener, MessageBusinessLogic, Message
                         mime: mimeType, fname: filename,
                         refurl: srvUrl, size: data.count) {
                         _ = topic.store?.msgReady(topic: topic, dbMessageId: msgId, data: content)
-                        topic.syncOne(msgId: msgId)?.thenFinally(finally: {
+                        topic.syncOne(msgId: msgId).thenFinally(finally: {
                             interactor?.loadMessages()
                         })
                         success = true

--- a/Tinodios/MessageInteractor.swift
+++ b/Tinodios/MessageInteractor.swift
@@ -17,7 +17,7 @@ protocol MessageBusinessLogic: class {
     func cleanup()
     func leaveTopic()
 
-    func sendMessage(content: Drafty) -> Bool
+    func sendMessage(content: Drafty)
     func sendReadNotification(explicitSeq: Int?, when deadline: DispatchTime)
     func sendTypingNotification()
     func enablePeersMessaging()
@@ -120,81 +120,81 @@ class MessageInteractor: DefaultComTopic.Listener, MessageBusinessLogic, Message
             tinode.reconnectNow(interactively: interactively, reset: false)
             return false
         }
-        do {
-            var builder = topic.getMetaGetBuilder()
-                .withDesc()
-                .withSub()
-                .withLaterData(limit: MessageInteractor.kMessagesPerPage)
-                .withDel()
-            if topic.isOwner {
-                builder = builder.withTags()
-            }
-            try topic.subscribe(set: nil, get: builder.build())?.then(
-                    onSuccess: { [weak self] _ in
-                        self?.messageInteractorQueue.async {
-                            do {
-                                try _ = self?.topic?.syncAll()?.thenApply(onSuccess: { [weak self] _ in
-                                    self?.loadMessages()
-                                    return nil
-                                })
-                            } catch {
-                                Cache.log.error("MessageInteractor - Failed to send pending messages: %@", error.localizedDescription)
-                            }
-                        }
-                        if self?.topicId == -1 {
-                            self?.topicId = BaseDb.getInstance().topicDb?.getId(topic: self?.topicName)
-                        }
-                        self?.loadMessages()
-                        self?.presenter?.applyTopicPermissions(withError: nil)
-                        return nil
-                    },
-                    onFailure: { [weak self] err in
-                        let tinode = Cache.getTinode()
-                        let errorMsg = "Failed to subscribe to topic: \(err.localizedDescription)"
-                        if tinode.isConnected {
-                            DispatchQueue.main.async {
-                                UiUtils.showToast(message: errorMsg)
-                            }
-                        } else {
-                            Cache.log.error("MessageInteractor: %@", errorMsg)
-                        }
-                        switch err {
-                        case TinodeError.notConnected(_):
-                            tinode.reconnectNow(interactively: false, reset: false)
-                        default:
-                            self?.presenter?.applyTopicPermissions(withError: err)
-                        }
-                        return nil
-                    })
-        } catch TinodeError.notConnected(let errorMsg) {
-            Cache.log.error("MessageInteractor - Tinode isn't connected: %@", errorMsg)
-        } catch {
-            Cache.log.error("MessageInteractor - error subscribing to topic: %@", error.localizedDescription)
+        var builder = topic.getMetaGetBuilder()
+            .withDesc()
+            .withSub()
+            .withLaterData(limit: MessageInteractor.kMessagesPerPage)
+            .withDel()
+        if topic.isOwner {
+            builder = builder.withTags()
         }
+        topic.subscribe(set: nil, get: builder.build())?.then(
+                onSuccess: { [weak self] _ in
+                    self?.messageInteractorQueue.async {
+                        self?.topic?.syncAll()?.then(
+                            onSuccess: { [weak self] _ in
+                                self?.loadMessages()
+                                return nil
+                            },
+                            onFailure: { err in
+                                Cache.log.error("MessageInteractor - Failed to send pending messages: %@", err.localizedDescription)
+                                return nil
+                            }
+                        )
+                    }
+                    if self?.topicId == -1 {
+                        self?.topicId = BaseDb.getInstance().topicDb?.getId(topic: self?.topicName)
+                    }
+                    self?.loadMessages()
+                    self?.presenter?.applyTopicPermissions(withError: nil)
+                    return nil
+                },
+                onFailure: { [weak self] err in
+                    let tinode = Cache.getTinode()
+                    let errorMsg = "Failed to subscribe to topic: \(err.localizedDescription)"
+                    if tinode.isConnected {
+                        DispatchQueue.main.async {
+                            UiUtils.showToast(message: errorMsg)
+                        }
+                    } else {
+                        Cache.log.error("MessageInteractor: %@", errorMsg)
+                    }
+                    switch err {
+                    case TinodeError.notConnected(_):
+                        tinode.reconnectNow(interactively: false, reset: false)
+                    default:
+                        self?.presenter?.applyTopicPermissions(withError: err)
+                    }
+                    return nil
+                })
+
         return false
     }
 
-    func sendMessage(content: Drafty) -> Bool {
-        guard let topic = self.topic else { return false }
+    func sendMessage(content: Drafty) {
+        guard let topic = self.topic else { return }
         defer {
             loadMessages()
         }
-        do {
-            _ = try topic.publish(content: content)?.then(
-                onSuccess: { [weak self] msg in
-                    self?.loadMessages()
-                    return nil
-                },
-                onFailure: UiUtils.ToastFailureHandler)
-        } catch TinodeError.notConnected {
-            DispatchQueue.main.async { UiUtils.showToast(message: "You are offline.") }
-            Cache.getTinode().reconnectNow(interactively: false, reset: false)
-            return false
-        } catch {
-            DispatchQueue.main.async { UiUtils.showToast(message: "Message not sent.") }
-            return false
-        }
-        return true
+        topic.publish(content: content)?.then(
+            onSuccess: { [weak self] msg in
+                self?.loadMessages()
+                return nil
+            },
+            onFailure: { err in
+                Cache.log.error("sendMessage error: %@", err.localizedDescription)
+                if let e = err as? TinodeError {
+                    switch e {
+                    case .notConnected(_):
+                        DispatchQueue.main.async { UiUtils.showToast(message: "You are offline.") }
+                        Cache.getTinode().reconnectNow(interactively: false, reset: false)
+                    default:
+                        DispatchQueue.main.async { UiUtils.showToast(message: "Message not sent.") }
+                    }
+                }
+                return nil
+            }
+        )
     }
     func sendReadNotification(explicitSeq: Int? = nil, when deadline: DispatchTime) {
         readNotificationsInFlight += 1
@@ -240,41 +240,23 @@ class MessageInteractor: DefaultComTopic.Listener, MessageBusinessLogic, Message
             return
         }
         if !loadNextPageInternal() && !StoredTopic.isAllDataLoaded(topic: t) {
-            do {
-                try t.getMeta(query:
-                    t.getMetaGetBuilder()
-                        .withEarlierData(
-                            limit: MessageInteractor.kMessagesPerPage)
-                        .build())?.then(
-                            onSuccess: { [weak self] msg in
-                                self?.presenter?.endRefresh()
-                                return nil
-                            },
-                            onFailure: { [weak self] err in
-                                self?.presenter?.endRefresh()
-                                return nil
-                            })
-            } catch {
-                self.presenter?.endRefresh()
-            }
+            t.getMeta(query:t.getMetaGetBuilder()
+                .withEarlierData(limit: MessageInteractor.kMessagesPerPage).build())?
+                .thenFinally(finally: { [weak self] in
+                    self?.presenter?.endRefresh()
+                })
         } else {
             self.presenter?.endRefresh()
         }
     }
     func deleteMessage(seqId: Int) {
-        do {
-            try topic?.delMessage(id: seqId, hard: false)?.then(
-                onSuccess: { [weak self] msg in
-                    self?.loadMessages()
-                    return nil
-                },
-                onFailure: UiUtils.ToastFailureHandler)
-            self.loadMessages()
-        } catch TinodeError.notConnected(_) {
-            UiUtils.showToast(message: "You are offline")
-        } catch {
-            UiUtils.showToast(message: "Action failed: \(error.localizedDescription)")
-        }
+        topic?.delMessage(id: seqId, hard: false)?.then(
+            onSuccess: { [weak self] msg in
+                self?.loadMessages()
+                return nil
+            },
+            onFailure: UiUtils.ToastFailureHandler)
+        self.loadMessages()
     }
 
     func enablePeersMessaging() {
@@ -284,65 +266,55 @@ class MessageInteractor: DefaultComTopic.Listener, MessageBusinessLogic, Message
         guard am.given?.update(from: "+RW") ?? false else {
             return
         }
-        do {
-            try topic?.setMeta(meta: MsgSetMeta(
-                desc: nil,
-                sub: MetaSetSub(user: topic?.name, mode: am.givenString),
-                tags: nil,
-                cred: nil))?.thenCatch(onFailure: UiUtils.ToastFailureHandler)
-        } catch TinodeError.notConnected(_) {
-            UiUtils.showToast(message: "You are offline")
-        } catch {
-            UiUtils.showToast(message: "Action failed: \(error.localizedDescription)")
-        }
+        topic?.setMeta(meta: MsgSetMeta(
+            desc: nil,
+            sub: MetaSetSub(user: topic?.name, mode: am.givenString),
+            tags: nil,
+            cred: nil))?.thenCatch(onFailure: UiUtils.ToastFailureHandler)
     }
+
     func acceptInvitation() {
         guard let topic = self.topic, let mode = self.topic?.accessMode?.givenString else { return }
         var response = topic.setMeta(meta: MsgSetMeta(desc: nil, sub: MetaSetSub(mode: mode), tags: nil, cred: nil))
         if topic.isP2PType {
             // For P2P topics change 'given' permission of the peer too.
             // In p2p topics the other user has the same name as the topic.
-            do {
-                response = try response?.thenApply(onSuccess: { msg in
+            response = response?.then(
+                onSuccess: { msg in
                     _ = topic.setMeta(meta: MsgSetMeta(
                         desc: nil,
                         sub: MetaSetSub(user: topic.name, mode: mode),
                         tags: nil,
                         cred: nil))
                     return nil
-                })
-            } catch TinodeError.notConnected(_) {
-                UiUtils.showToast(message: "You are offline")
-            } catch {
-                UiUtils.showToast(message: "Operation failed \(error.localizedDescription)")
-            }
+                },
+                onFailure: UiUtils.ToastFailureHandler
+            )
         }
-        _ = try? response?.thenApply(onSuccess: { msg in
+        response?.thenApply(onSuccess: { msg in
             self.presenter?.applyTopicPermissions(withError: nil)
             return nil
         })
     }
     func ignoreInvitation() {
-        _ = try? self.topic?.delete()?.thenFinally(
+        self.topic?.delete()?.thenFinally(
             finally: {
                 self.presenter?.dismiss()
             })
     }
+
     func blockTopic() {
         guard let origAm = self.topic?.accessMode else { return }
         let am = Acs(from: origAm)
         guard am.want?.update(from: "-JP") ?? false else { return }
-        do {
-            try self.topic?.setMeta(meta: MsgSetMeta(desc: nil, sub: MetaSetSub(mode: am.wantString), tags: nil, cred: nil))?.thenFinally(
+        self.topic?.setMeta(meta: MsgSetMeta(desc: nil, sub: MetaSetSub(mode: am.wantString), tags: nil, cred: nil))?
+            .thenCatch(onFailure: UiUtils.ToastFailureHandler)?
+            .thenFinally(
                 finally: {
                     self.presenter?.dismiss()
                 })
-        } catch TinodeError.notConnected(_) {
-            UiUtils.showToast(message: "You are offline")
-        } catch {
-            UiUtils.showToast(message: "Operation failed \(error.localizedDescription)")
-        }
     }
+
     static private func existingInteractor(for topicName: String?) -> MessageInteractor? {
         // Must be called on main thread.
         guard let topicName = topicName else { return nil }
@@ -356,6 +328,7 @@ class MessageInteractor: DefaultComTopic.Listener, MessageBusinessLogic, Message
         }
         return nil
     }
+
     func uploadFile(filename: String?, refurl: URL?, mimeType: String?, data: Data?) {
         guard let filename = filename, let mimeType = mimeType, let data = data, let topic = topic else { return }
         guard let content = try? Drafty().attachFile(mime: mimeType,
@@ -394,7 +367,7 @@ class MessageInteractor: DefaultComTopic.Listener, MessageBusinessLogic, Message
                         mime: mimeType, fname: filename,
                         refurl: srvUrl, size: data.count) {
                         _ = topic.store?.msgReady(topic: topic, dbMessageId: msgId, data: content)
-                        _ = try? topic.syncOne(msgId: msgId)?.thenFinally(finally: {
+                        topic.syncOne(msgId: msgId)?.thenFinally(finally: {
                             interactor?.loadMessages()
                         })
                         success = true

--- a/Tinodios/MessageViewController+SendMessageBarDelegate.swift
+++ b/Tinodios/MessageViewController+SendMessageBarDelegate.swift
@@ -13,8 +13,8 @@ extension MessageViewController : SendMessageBarDelegate {
     static let kMaxInbandAttachmentSize = 1 << 17
     static let kMaxAttachmentSize = 1 << 23
 
-    func sendMessageBar(sendText: String) -> Bool? {
-        return interactor?.sendMessage(content: Drafty(content: sendText))
+    func sendMessageBar(sendText: String) {
+        interactor?.sendMessage(content: Drafty(content: sendText))
     }
 
     func sendMessageBar(attachment: Bool) {

--- a/Tinodios/MessageViewController.swift
+++ b/Tinodios/MessageViewController.swift
@@ -136,7 +136,7 @@ class MessageViewController: UIViewController {
             let tinode = Cache.getTinode()
             topic = tinode.getTopic(topicName: topicName!) as? DefaultComTopic
             if topic == nil {
-                topic = tinode.newTopic(for: topicName!, with: nil) as? DefaultComTopic
+                topic = tinode.newTopic(for: topicName!) as? DefaultComTopic
             }
         }
     }

--- a/Tinodios/NewGroupViewController.swift
+++ b/Tinodios/NewGroupViewController.swift
@@ -173,22 +173,19 @@ class NewGroupViewController: UITableViewController {
         topic.pub = VCard(fn: name, avatar: avatar)
         topic.priv = ["comment": .string(subtitle)] // No need to use Tinode.kNullValue here
         topic.tags = tags
-        do {
-            try topic.subscribe()?.then(
-                onSuccess: { msg in
-                    for u in members {
-                        topic.invite(user: u, in: nil)
-                    }
-                    // Need to unsubscribe because routing to MessageVC (below)
-                    // will subscribe to the topic again.
-                    topic.leave()
-                    // Route to chat.
-                    self.presentChat(with: topic.name)
-                    return nil
-            },onFailure: UiUtils.ToastFailureHandler)
-        } catch {
-            UiUtils.showToast(message: "Failed to create group: \(error.localizedDescription)")
-        }
+        topic.subscribe()?.then(
+            onSuccess: { msg in
+                for u in members {
+                    topic.invite(user: u, in: nil)
+                }
+                // Need to unsubscribe because routing to MessageVC (below)
+                // will subscribe to the topic again.
+                topic.leave()
+                // Route to chat.
+                self.presentChat(with: topic.name)
+                return nil
+            },
+            onFailure: UiUtils.ToastFailureHandler)
     }
 }
 

--- a/Tinodios/NewGroupViewController.swift
+++ b/Tinodios/NewGroupViewController.swift
@@ -173,7 +173,7 @@ class NewGroupViewController: UITableViewController {
         topic.pub = VCard(fn: name, avatar: avatar)
         topic.priv = ["comment": .string(subtitle)] // No need to use Tinode.kNullValue here
         topic.tags = tags
-        topic.subscribe()?.then(
+        topic.subscribe().then(
             onSuccess: { msg in
                 for u in members {
                     topic.invite(user: u, in: nil)

--- a/Tinodios/ResetPasswordViewController.swift
+++ b/Tinodios/ResetPasswordViewController.swift
@@ -73,17 +73,17 @@ class ResetPasswordViewController : UIViewController {
         UiUtils.toggleProgressOverlay(in: self, visible: true, title: "Requesting...")
         do {
             try tinode.connectDefault()?
-                .thenApply(onSuccess: { _ in
+                .thenApply({ _ in
                     return tinode.requestResetPassword(method: credential.methodName(), newValue: normalized)
                 })
-                .thenApply(onSuccess: { _ in
+                .thenApply({ _ in
                     DispatchQueue.main.async { UiUtils.showToast(message: "Message with instructions sent to the provided address.") }
                     DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1)) { [weak self] in
                         self?.navigationController?.popViewController(animated: true)
                     }
                     return nil
                 })
-                .thenCatch(onFailure: UiUtils.ToastFailureHandler)
+                .thenCatch(UiUtils.ToastFailureHandler)
                 .thenFinally {
                     UiUtils.toggleProgressOverlay(in: self, visible: false)
                 }

--- a/Tinodios/ResetPasswordViewController.swift
+++ b/Tinodios/ResetPasswordViewController.swift
@@ -75,15 +75,15 @@ class ResetPasswordViewController : UIViewController {
             try tinode.connectDefault()?
                 .thenApply(onSuccess: { _ in
                     return tinode.requestResetPassword(method: credential.methodName(), newValue: normalized)
-                })?
+                })
                 .thenApply(onSuccess: { _ in
                     DispatchQueue.main.async { UiUtils.showToast(message: "Message with instructions sent to the provided address.") }
                     DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1)) { [weak self] in
                         self?.navigationController?.popViewController(animated: true)
                     }
                     return nil
-                })?
-                .thenCatch(onFailure: UiUtils.ToastFailureHandler)?
+                })
+                .thenCatch(onFailure: UiUtils.ToastFailureHandler)
                 .thenFinally {
                     UiUtils.toggleProgressOverlay(in: self, visible: false)
                 }

--- a/Tinodios/SignupViewController.swift
+++ b/Tinodios/SignupViewController.swift
@@ -92,12 +92,11 @@ class SignupViewController: UITableViewController {
         UiUtils.toggleProgressOverlay(in: self, visible: true, title: "Registering...")
         do {
             try tinode.connectDefault()?
-                .thenApply({ pkt in
-                    print("Successfully connected, creating account")
+                .thenApply { pkt in
                     return tinode.createAccountBasic(
                         uname: login, pwd: pwd, login: true,
                         tags: nil, desc: desc, creds: creds)
-                }).thenApply({ [weak self] msg in
+                }.thenApply { [weak self] msg in
                     if let ctrl = msg?.ctrl, ctrl.code >= 300, ctrl.text.contains("validate credentials") {
                         DispatchQueue.main.async {
                             UiUtils.routeToCredentialsVC(in: self!.navigationController,
@@ -110,19 +109,20 @@ class SignupViewController: UITableViewController {
                         UiUtils.routeToChatListVC()
                     }
                     return nil
-                }).thenCatch({ err in
+                }.thenCatch { err in
+                    Cache.log.error("Failed to create account: %@", err.localizedDescription)
                     DispatchQueue.main.async {
                         UiUtils.showToast(message: "Failed to create account: \(err.localizedDescription)")
                     }
                     tinode.disconnect()
                     return nil
-                }).thenFinally({ [weak self] in
+                }.thenFinally { [weak self] in
                     guard let signupVC = self else { return }
                     DispatchQueue.main.async {
                         signupVC.signUpButton.isUserInteractionEnabled = true
                         UiUtils.toggleProgressOverlay(in: signupVC, visible: false)
                     }
-                })
+                }
         } catch {
             tinode.disconnect()
             DispatchQueue.main.async {

--- a/Tinodios/SignupViewController.swift
+++ b/Tinodios/SignupViewController.swift
@@ -91,14 +91,13 @@ class SignupViewController: UITableViewController {
         creds.append(cred)
         UiUtils.toggleProgressOverlay(in: self, visible: true, title: "Registering...")
         do {
-            try tinode.connectDefault()?.thenApply(
-                    onSuccess: { pkt in
-                        print("Successfully connected, creating account")
-                        return tinode.createAccountBasic(
-                            uname: login, pwd: pwd, login: true,
-                            tags: nil, desc: desc, creds: creds)
-            }).thenApply(
-                onSuccess: { [weak self] msg in
+            try tinode.connectDefault()?
+                .thenApply({ pkt in
+                    print("Successfully connected, creating account")
+                    return tinode.createAccountBasic(
+                        uname: login, pwd: pwd, login: true,
+                        tags: nil, desc: desc, creds: creds)
+                }).thenApply({ [weak self] msg in
                     if let ctrl = msg?.ctrl, ctrl.code >= 300, ctrl.text.contains("validate credentials") {
                         DispatchQueue.main.async {
                             UiUtils.routeToCredentialsVC(in: self!.navigationController,
@@ -111,20 +110,19 @@ class SignupViewController: UITableViewController {
                         UiUtils.routeToChatListVC()
                     }
                     return nil
-            }).thenCatch(
-                onFailure: { err in
+                }).thenCatch({ err in
                     DispatchQueue.main.async {
                         UiUtils.showToast(message: "Failed to create account: \(err.localizedDescription)")
                     }
                     tinode.disconnect()
                     return nil
-            }).thenFinally(finally: { [weak self] in
-                guard let signupVC = self else { return }
-                DispatchQueue.main.async {
-                    signupVC.signUpButton.isUserInteractionEnabled = true
-                    UiUtils.toggleProgressOverlay(in: signupVC, visible: false)
-                }
-            })
+                }).thenFinally({ [weak self] in
+                    guard let signupVC = self else { return }
+                    DispatchQueue.main.async {
+                        signupVC.signUpButton.isUserInteractionEnabled = true
+                        UiUtils.toggleProgressOverlay(in: signupVC, visible: false)
+                    }
+                })
         } catch {
             tinode.disconnect()
             DispatchQueue.main.async {

--- a/Tinodios/SignupViewController.swift
+++ b/Tinodios/SignupViewController.swift
@@ -97,7 +97,7 @@ class SignupViewController: UITableViewController {
                         return tinode.createAccountBasic(
                             uname: login, pwd: pwd, login: true,
                             tags: nil, desc: desc, creds: creds)
-            })?.thenApply(
+            }).thenApply(
                 onSuccess: { [weak self] msg in
                     if let ctrl = msg?.ctrl, ctrl.code >= 300, ctrl.text.contains("validate credentials") {
                         DispatchQueue.main.async {
@@ -111,14 +111,14 @@ class SignupViewController: UITableViewController {
                         UiUtils.routeToChatListVC()
                     }
                     return nil
-            })?.thenCatch(
+            }).thenCatch(
                 onFailure: { err in
                     DispatchQueue.main.async {
                         UiUtils.showToast(message: "Failed to create account: \(err.localizedDescription)")
                     }
                     tinode.disconnect()
                     return nil
-            })?.thenFinally(finally: { [weak self] in
+            }).thenFinally(finally: { [weak self] in
                 guard let signupVC = self else { return }
                 DispatchQueue.main.async {
                     signupVC.signUpButton.isUserInteractionEnabled = true

--- a/Tinodios/TopicInfoViewController.swift
+++ b/Tinodios/TopicInfoViewController.swift
@@ -212,7 +212,7 @@ class TopicInfoViewController: UITableViewController {
 
     @IBAction func mutedSwitched(_ sender: Any) {
         let isChecked = mutedSwitch.isOn
-        topic.updateMuted(muted: isChecked)?.then(
+        topic.updateMuted(muted: isChecked).then(
             onSuccess: UiUtils.ToastSuccessHandler,
             onFailure: { err in
                 self.mutedSwitch.isOn = !isChecked
@@ -319,7 +319,7 @@ class TopicInfoViewController: UITableViewController {
     }
 
     private func deleteTopic() {
-        topic.delete()?.then(
+        topic.delete().then(
             onSuccess: { msg in
                 DispatchQueue.main.async {
                     let storyboard = UIStoryboard(name: "Main", bundle: nil)
@@ -333,7 +333,7 @@ class TopicInfoViewController: UITableViewController {
     }
 
     private func blockContact() {
-        topic.updateMode(uid: nil, update: "-JP")?.then(
+        topic.updateMode(uid: nil, update: "-JP").then(
             onSuccess: { msg in
                 DispatchQueue.main.async {
                     let storyboard = UIStoryboard(name: "Main", bundle: nil)
@@ -375,7 +375,7 @@ class TopicInfoViewController: UITableViewController {
 
     @objc func deleteMessagesClicked(sender: UITapGestureRecognizer) {
         let handler: (Bool) -> Void = { (hard: Bool) -> Void in
-            self.topic?.delMessages(hard: hard)?.thenCatch(onFailure: UiUtils.ToastFailureHandler)
+            self.topic?.delMessages(hard: hard).thenCatch(onFailure: UiUtils.ToastFailureHandler)
         }
 
         let alert = UIAlertController(title: "Clear all messages?", message: nil, preferredStyle: .alert)
@@ -652,7 +652,7 @@ extension TopicInfoViewController {
             case .ban:
                 ban = true
             }
-            self.topic.eject(user: uid, ban: ban)?.then(
+            self.topic.eject(user: uid, ban: ban).then(
                 onSuccess: self.promiseSuccessHandler,
                 onFailure: UiUtils.ToastFailureHandler)
         }))
@@ -693,7 +693,7 @@ extension TopicInfoViewController {
                 UiUtils.showToast(message: "Can't make this user owner.")
                 return
             }
-            self.topic.updateMode(uid: uid, update: "+O")?.then(
+            self.topic.updateMode(uid: uid, update: "+O").then(
                 onSuccess: self.promiseSuccessHandler,
                 onFailure: UiUtils.ToastFailureHandler)
         }))
@@ -723,10 +723,10 @@ extension TopicInfoViewController: EditMembersDelegate {
 
     func editMembersDidEndEditing(_: UIView, added: [String], removed: [String]) {
          for uid in added {
-            topic.invite(user: uid, in: nil)?.thenCatch(onFailure: UiUtils.ToastFailureHandler)
+            topic.invite(user: uid, in: nil).thenCatch(onFailure: UiUtils.ToastFailureHandler)
          }
          for uid in removed {
-            topic.eject(user: uid, ban: false)?.thenCatch(onFailure: UiUtils.ToastFailureHandler)
+            topic.eject(user: uid, ban: false).thenCatch(onFailure: UiUtils.ToastFailureHandler)
          }
     }
 

--- a/Tinodios/TopicInfoViewController.swift
+++ b/Tinodios/TopicInfoViewController.swift
@@ -218,7 +218,7 @@ class TopicInfoViewController: UITableViewController {
                 onFailure: { err in
                     self.mutedSwitch.isOn = !isChecked
                     return nil
-                })?.thenFinally(finally: {
+                }).thenFinally(finally: {
                     DispatchQueue.main.async { self.reloadData() }
                 })
         } catch TinodeError.notConnected(_) {

--- a/Tinodios/TopicInfoViewController.swift
+++ b/Tinodios/TopicInfoViewController.swift
@@ -220,7 +220,7 @@ class TopicInfoViewController: UITableViewController {
                     UiUtils.showToast(message: "You are offline.")
                 }
                 return nil
-            }).thenFinally(finally: {
+            }).thenFinally({
                 DispatchQueue.main.async { self.reloadData() }
             })
     }
@@ -375,7 +375,7 @@ class TopicInfoViewController: UITableViewController {
 
     @objc func deleteMessagesClicked(sender: UITapGestureRecognizer) {
         let handler: (Bool) -> Void = { (hard: Bool) -> Void in
-            self.topic?.delMessages(hard: hard).thenCatch(onFailure: UiUtils.ToastFailureHandler)
+            self.topic?.delMessages(hard: hard).thenCatch(UiUtils.ToastFailureHandler)
         }
 
         let alert = UIAlertController(title: "Clear all messages?", message: nil, preferredStyle: .alert)
@@ -723,10 +723,10 @@ extension TopicInfoViewController: EditMembersDelegate {
 
     func editMembersDidEndEditing(_: UIView, added: [String], removed: [String]) {
          for uid in added {
-            topic.invite(user: uid, in: nil).thenCatch(onFailure: UiUtils.ToastFailureHandler)
+            topic.invite(user: uid, in: nil).thenCatch(UiUtils.ToastFailureHandler)
          }
          for uid in removed {
-            topic.eject(user: uid, ban: false).thenCatch(onFailure: UiUtils.ToastFailureHandler)
+            topic.eject(user: uid, ban: false).thenCatch(UiUtils.ToastFailureHandler)
          }
     }
 

--- a/Tinodios/TopicInfoViewController.swift
+++ b/Tinodios/TopicInfoViewController.swift
@@ -212,21 +212,17 @@ class TopicInfoViewController: UITableViewController {
 
     @IBAction func mutedSwitched(_ sender: Any) {
         let isChecked = mutedSwitch.isOn
-        do {
-            try topic.updateMuted(muted: isChecked)?.then(
-                onSuccess: UiUtils.ToastSuccessHandler,
-                onFailure: { err in
-                    self.mutedSwitch.isOn = !isChecked
-                    return nil
-                }).thenFinally(finally: {
-                    DispatchQueue.main.async { self.reloadData() }
-                })
-        } catch TinodeError.notConnected(_) {
-            mutedSwitch.isOn = !isChecked
-            UiUtils.showToast(message: "You are offline.")
-        } catch {
-            mutedSwitch.isOn = !isChecked
-        }
+        topic.updateMuted(muted: isChecked)?.then(
+            onSuccess: UiUtils.ToastSuccessHandler,
+            onFailure: { err in
+                self.mutedSwitch.isOn = !isChecked
+                if let e = err as? TinodeError, case .notConnected(_) = e {
+                    UiUtils.showToast(message: "You are offline.")
+                }
+                return nil
+            }).thenFinally(finally: {
+                DispatchQueue.main.async { self.reloadData() }
+            })
     }
 
     @objc
@@ -273,7 +269,7 @@ class TopicInfoViewController: UITableViewController {
             }
         }
         if pub != nil || priv != nil {
-            try? UiUtils.setTopicData(forTopic: topic, pub: pub, priv: priv)?.thenFinally {
+            UiUtils.setTopicData(forTopic: topic, pub: pub, priv: priv)?.thenFinally {
                 DispatchQueue.main.async { self.reloadData() }
             }
         }
@@ -286,7 +282,7 @@ class TopicInfoViewController: UITableViewController {
         }
         UiUtils.showPermissionsEditDialog(over: self, acs: acs, callback: {
             permissions in
-            _ = try? UiUtils.handlePermissionsChange(onTopic: self.topic, forUid: uid, changeType: changeType, newPermissions: permissions)?.then(onSuccess: self.promiseSuccessHandler)
+            UiUtils.handlePermissionsChange(onTopic: self.topic, forUid: uid, changeType: changeType, newPermissions: permissions)?.then(onSuccess: self.promiseSuccessHandler)
         }, disabledPermissions: disabledPermissions)
     }
 
@@ -323,29 +319,8 @@ class TopicInfoViewController: UITableViewController {
     }
 
     private func deleteTopic() {
-        do {
-            try topic.delete()?.then(
-                onSuccess: { msg in
-                    DispatchQueue.main.async {
-                        let storyboard = UIStoryboard(name: "Main", bundle: nil)
-                        let destinationVC = storyboard.instantiateViewController(withIdentifier: "ChatsNavigator") as! UINavigationController
-
-                        self.show(destinationVC, sender: nil)
-                    }
-                    return nil
-                },
-                onFailure: UiUtils.ToastFailureHandler)
-        } catch TinodeError.notConnected(let e) {
-            UiUtils.showToast(message: "You are offline \(e)")
-        } catch {
-            UiUtils.showToast(message: "Action failed \(error)")
-        }
-    }
-
-    private func blockContact() {
-        do {
-            try topic.updateMode(uid: nil, update: "-JP")?.then(
-                onSuccess: { msg in
+        topic.delete()?.then(
+            onSuccess: { msg in
                 DispatchQueue.main.async {
                     let storyboard = UIStoryboard(name: "Main", bundle: nil)
                     let destinationVC = storyboard.instantiateViewController(withIdentifier: "ChatsNavigator") as! UINavigationController
@@ -355,11 +330,19 @@ class TopicInfoViewController: UITableViewController {
                 return nil
             },
             onFailure: UiUtils.ToastFailureHandler)
-        } catch TinodeError.notConnected(let e) {
-            UiUtils.showToast(message: "You are offline \(e)")
-        } catch {
-            UiUtils.showToast(message: "Action failed \(error)")
-        }
+    }
+
+    private func blockContact() {
+        topic.updateMode(uid: nil, update: "-JP")?.then(
+            onSuccess: { msg in
+                DispatchQueue.main.async {
+                    let storyboard = UIStoryboard(name: "Main", bundle: nil)
+                    let destinationVC = storyboard.instantiateViewController(withIdentifier: "ChatsNavigator") as! UINavigationController
+                    self.show(destinationVC, sender: nil)
+                }
+                return nil
+            },
+            onFailure: UiUtils.ToastFailureHandler)
     }
 
     private func reportTopic(reason: String) {
@@ -392,11 +375,7 @@ class TopicInfoViewController: UITableViewController {
 
     @objc func deleteMessagesClicked(sender: UITapGestureRecognizer) {
         let handler: (Bool) -> Void = { (hard: Bool) -> Void in
-            do {
-                try self.topic?.delMessages(hard: hard)?.thenCatch(onFailure: UiUtils.ToastFailureHandler)
-            } catch {
-                UiUtils.showToast(message: "Failed to delete messages: \(error)")
-            }
+            self.topic?.delMessages(hard: hard)?.thenCatch(onFailure: UiUtils.ToastFailureHandler)
         }
 
         let alert = UIAlertController(title: "Clear all messages?", message: nil, preferredStyle: .alert)
@@ -673,7 +652,7 @@ extension TopicInfoViewController {
             case .ban:
                 ban = true
             }
-            _ = try? self.topic.eject(user: uid, ban: ban)?.then(
+            self.topic.eject(user: uid, ban: ban)?.then(
                 onSuccess: self.promiseSuccessHandler,
                 onFailure: UiUtils.ToastFailureHandler)
         }))
@@ -714,13 +693,9 @@ extension TopicInfoViewController {
                 UiUtils.showToast(message: "Can't make this user owner.")
                 return
             }
-            do {
-                try self.topic.updateMode(uid: uid, update: "+O")?.then(
-                    onSuccess: self.promiseSuccessHandler,
-                    onFailure: UiUtils.ToastFailureHandler)
-            } catch {
-                UiUtils.showToast(message: "Operation failed \(error).")
-            }
+            self.topic.updateMode(uid: uid, update: "+O")?.then(
+                onSuccess: self.promiseSuccessHandler,
+                onFailure: UiUtils.ToastFailureHandler)
         }))
         let topicTitle = self.topic.pub?.fn ?? "Unknown"
         let title = sub.pub?.fn ?? "Unknown"
@@ -748,10 +723,10 @@ extension TopicInfoViewController: EditMembersDelegate {
 
     func editMembersDidEndEditing(_: UIView, added: [String], removed: [String]) {
          for uid in added {
-            _ = try? topic.invite(user: uid, in: nil)?.thenCatch(onFailure: UiUtils.ToastFailureHandler)
+            topic.invite(user: uid, in: nil)?.thenCatch(onFailure: UiUtils.ToastFailureHandler)
          }
          for uid in removed {
-            _ = try? topic.eject(user: uid, ban: false)?.thenCatch(onFailure: UiUtils.ToastFailureHandler)
+            topic.eject(user: uid, ban: false)?.thenCatch(onFailure: UiUtils.ToastFailureHandler)
          }
     }
 
@@ -765,7 +740,6 @@ extension TopicInfoViewController: ImagePickerDelegate {
         guard let image = image?.resize(width: UiUtils.kAvatarSize, height: UiUtils.kAvatarSize, clip: true) else {
             return
         }
-        _ = try? UiUtils.updateAvatar(forTopic: self.topic, image: image)?.then(
-            onSuccess: self.promiseSuccessHandler)
+        UiUtils.updateAvatar(forTopic: self.topic, image: image)?.then(onSuccess: self.promiseSuccessHandler)
     }
 }

--- a/Tinodios/UiUtils.swift
+++ b/Tinodios/UiUtils.swift
@@ -118,7 +118,7 @@ class UiUtils {
             me!.listener = meListener
         }
         let get = me!.getMetaGetBuilder().withDesc().withSub().withTags().withCred().build()
-        return me!.subscribe(set: nil, get: get)?.thenCatch(onFailure: { err in
+        return me!.subscribe(set: nil, get: get).thenCatch(onFailure: { err in
             Cache.log.error("ME topic subscription error: %@", err.localizedDescription)
             if let e = err as? TinodeError {
                 if case TinodeError.serverResponseError(let code, let text, _) = e {
@@ -348,6 +348,7 @@ class UiUtils {
         tap.cancelsTouchesInView = false
         view.addGestureRecognizer(tap)
     }
+    @discardableResult
     public static func ToastFailureHandler(err: Error) -> PromisedReply<ServerMessage>? {
         DispatchQueue.main.async {
             if let e = err as? TinodeError, case .notConnected = e {
@@ -358,6 +359,7 @@ class UiUtils {
         }
         return nil
     }
+    @discardableResult
     public static func ToastSuccessHandler(msg: ServerMessage?) -> PromisedReply<ServerMessage>? {
         if let ctrl = msg?.ctrl, ctrl.code >= 300 {
             DispatchQueue.main.async {
@@ -414,7 +416,7 @@ class UiUtils {
     @discardableResult
     public static func setTopicData(
         forTopic topic: DefaultTopic, pub: VCard?, priv: PrivateType?) -> PromisedReply<ServerMessage>? {
-        return topic.setDescription(pub: pub, priv: priv)?.then(
+        return topic.setDescription(pub: pub, priv: priv).then(
             onSuccess: UiUtils.ToastSuccessHandler,
             onFailure: UiUtils.ToastFailureHandler)
     }
@@ -473,7 +475,7 @@ class UiUtils {
         }
         let alert = TagsEditDialogViewController(with: tags)
         alert.completionHandler = { newTags in
-            topic.setMeta(meta: MsgSetMeta(desc: nil, sub: nil, tags: newTags, cred: nil))?.thenCatch(onFailure: UiUtils.ToastFailureHandler)
+            topic.setMeta(meta: MsgSetMeta(desc: nil, sub: nil, tags: newTags, cred: nil)).thenCatch(onFailure: UiUtils.ToastFailureHandler)
         }
         alert.show(over: viewController)
     }

--- a/Tinodios/UiUtils.swift
+++ b/Tinodios/UiUtils.swift
@@ -238,12 +238,18 @@ class UiUtils {
         return maxLength > 0 ? String(text.prefix(maxLength)) : text
     }
     public static func markTextFieldAsError(_ field: UITextField) {
-        field.rightViewMode = .always
-        let imageView = UIImageView(frame: CGRect(x: 0, y: 0, width: 28, height: 20))
-        imageView.image = UIImage(named: "important-32")
+        let imageView = UIImageView(image: UIImage(named: "important-32"))
         imageView.contentMode = .scaleAspectFit
+        imageView.frame = CGRect(x: 0, y: 0, width: 24, height: 24)
         imageView.tintColor = .red
-        field.rightView = imageView
+        // Padding around the icon
+        let padding: CGFloat = 4
+        // Create the view that would act as the padding
+        let rightView = UIView(frame: CGRect(x: 0, y: 0, // keep this as 0, 0
+            width: imageView.frame.width + padding, height: imageView.frame.height))
+        rightView.addSubview(imageView)
+        field.rightViewMode = .always
+        field.rightView = rightView
     }
     public static func clearTextFieldError(_ field: UITextField) {
         field.rightViewMode = .never

--- a/Tinodios/account/ContactsSynchronizer.swift
+++ b/Tinodios/account/ContactsSynchronizer.swift
@@ -140,15 +140,9 @@ class ContactsSynchronizer {
                 _ = try tinode.subscribe(to: Tinode.kTopicFnd, set: MsgSetMeta<Int, Int>?(nil), get: nil, background: false)?.getResult()
                 //let q: Int? = nil
                 let metaDesc: MetaSetDesc<Int, String> = MetaSetDesc(pub: nil, priv: contacts)
-                let setMeta: MsgSetMeta<Int, String> = MsgSetMeta<Int, String>(
-                    desc: metaDesc, sub: nil, tags: nil, cred: nil)
-                _ = try tinode.setMeta(
-                    for: Tinode.kTopicFnd,
-                    meta: setMeta)?.getResult()
-                let meta = MsgGetMeta(
-                    desc: nil,
-                    sub: MetaGetSub(user: nil, ims: lastSyncMarker, limit: nil),
-                    data: nil, del: nil, tags: false)
+                let setMeta: MsgSetMeta<Int, String> = MsgSetMeta<Int, String>(desc: metaDesc, sub: nil, tags: nil, cred: nil)
+                _ = try tinode.setMeta(for: Tinode.kTopicFnd, meta: setMeta)?.getResult()
+                let meta = MsgGetMeta(desc: nil, sub: MetaGetSub(user: nil, ims: lastSyncMarker, limit: nil), data: nil, del: nil, tags: false, cred: false)
                 if let future = tinode.getMeta(topic: Tinode.kTopicFnd, query: meta) {
                     if try future.waitResult() {
                         let pkt = try! future.getResult()

--- a/Tinodios/widgets/SendMessageBar.swift
+++ b/Tinodios/widgets/SendMessageBar.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol SendMessageBarDelegate: class {
-    func sendMessageBar(sendText: String) -> Bool?
+    func sendMessageBar(sendText: String)
 
     func sendMessageBar(attachment: Bool)
 
@@ -60,10 +60,9 @@ class SendMessageBar: UIView {
         if msg.isEmpty {
             return
         }
-        if delegate?.sendMessageBar(sendText: msg) ?? false {
-            inputField.text = nil
-            textViewDidChange(inputField)
-        }
+        delegate?.sendMessageBar(sendText: msg)
+        inputField.text = nil
+        textViewDidChange(inputField)
     }
 
     @IBAction func enablePeerMessagingClicked(_ sender: Any) {

--- a/TinodiosDB/AccountDb.swift
+++ b/TinodiosDB/AccountDb.swift
@@ -105,6 +105,7 @@ public class AccountDb {
         }
         return nil
     }
+    @discardableResult
     func saveDeviceToken(token: String?) -> Bool {
         let record = self.table.filter(self.active == 1)
         do {

--- a/TinodiosDB/BaseDb.swift
+++ b/TinodiosDB/BaseDb.swift
@@ -11,7 +11,7 @@ import TinodeSDK
 
 public class BaseDb {
     // Current database schema version. Increment on schema changes.
-    public static let kSchemaVersion: Int32 = 104
+    public static let kSchemaVersion: Int32 = 105
 
     // Onject statuses.
     // Status undefined/not set.

--- a/TinodiosDB/TopicDb.swift
+++ b/TinodiosDB/TopicDb.swift
@@ -52,6 +52,7 @@ public class TopicDb {
     public let maxLocalSeq: Expression<Int?>
     public let nextUnsentSeq: Expression<Int?>
     public let tags: Expression<String?>
+    public let creds: Expression<String?>
     public let pub: Expression<String?>
     public let priv: Expression<String?>
 
@@ -81,6 +82,7 @@ public class TopicDb {
         self.maxLocalSeq = Expression<Int?>("max_local_seq")
         self.nextUnsentSeq = Expression<Int?>("next_unsent_seq")
         self.tags = Expression<String?>("tags")
+        self.creds = Expression<String?>("creds")
         self.pub = Expression<String?>("pub")
         self.priv = Expression<String?>("priv")
     }
@@ -116,6 +118,7 @@ public class TopicDb {
             t.column(nextUnsentSeq)
 
             t.column(tags)
+            t.column(creds)
             t.column(pub)
             t.column(priv)
         })
@@ -137,6 +140,9 @@ public class TopicDb {
         topic.seq = row[self.seq]
         topic.clear = row[self.clear]
         topic.maxDel = row[self.maxDel] ?? 0
+        if topic is MeTopicProto {
+            (topic as! MeTopicProto).deserializeCreds(from: row[self.creds])
+        }
         topic.tags = row[self.tags]?.components(separatedBy: ",")
 
         topic.accessMode = Acs.deserialize(from: row[self.accessMode])
@@ -231,6 +237,7 @@ public class TopicDb {
                     nextUnsentSeq <- TopicDb.kUnsentIdStart,
 
                     tags <- topic.tags?.joined(separator: ","),
+                    creds <- topic is MeTopicProto ? (topic as! MeTopicProto).serializeCreds() : nil,
                     pub <- topic.serializePub(),
                     priv <- topic.serializePriv()
                 ))

--- a/TinodiosDB/TopicDb.swift
+++ b/TinodiosDB/TopicDb.swift
@@ -191,7 +191,7 @@ public class TopicDb {
             return nil
         }
         //let t = Tinode.newTopic(for: topicName, with: nil)
-        let t = Tinode.newTopic(withTinode: tinode, forTopic: topicName, withListener: nil)
+        let t = Tinode.newTopic(withTinode: tinode, forTopic: topicName)
         self.deserializeTopic(topic: t, row: row)
         return t
     }

--- a/TinodiosDB/UserDb.swift
+++ b/TinodiosDB/UserDb.swift
@@ -84,7 +84,7 @@ public class UserDb {
             ))
             return rowid
         } catch {
-            BaseDb.log.error("UserDb - insert operation failed: uid = %@, error = %@", uid ?? "", error.localizedDescription)
+            BaseDb.log.error("UserDb - insert operation failed: uid = %@, error = %@", uid, error.localizedDescription)
             return -1
         }
     }


### PR DESCRIPTION
* Got rid of do ... try ... catch everywhere where PromisedReply is returned.
* Got rid of all optional returns with PromisedReply: `-> PromisedReply<ServerMessage>?` replaced with `-> PromisedReply<ServerMessage>`.
* Got rid of unnecessary arg names in `PromisedReply.thenApply` and `thenCatch`.
* Crash in Drafty (caught on Android with Crashlytics): `fmt.at` or `fmt.at + fmt.len` could be out of bounds. It was not a problem with the original JS code. That got copied without the check to Android then replicated to iOS.
* Saving user's email/phone number to DB, otherwise crash on disconnected device.
* Adding/deleting/confirming credentials work now.
* Moved eye icon in password field to the left to make space for ( i ) icon when the field is required but not filled.
