### PR TITLE
Failed promises incorrectly recovered

### DIFF
--- a/TinodeSDK/Tinode.swift
+++ b/TinodeSDK/Tinode.swift
@@ -940,7 +940,7 @@ public class Tinode {
             }, onFailure: { err in
                 Tinode.log.error("Connection error: %@", err.localizedDescription)
                 try self.rejectAllPromises(err: err)
-                return nil
+                return PromisedReply<ServerMessage>(error: err)
             })
             if doLogin {
                 future.then(
@@ -954,7 +954,7 @@ public class Tinode {
                                     },
                                     onFailure: { err in
                                         try self?.rejectAllPromises(err: err)
-                                        return nil
+                                        return PromisedReply<ServerMessage>(error: err)
                                     })
                         }
                         return nil
@@ -962,7 +962,7 @@ public class Tinode {
                     onFailure: { [weak self] err in
                         Tinode.log.error("Connection error: %@", err.localizedDescription)
                         try self?.rejectAllPromises(err: err)
-                        return nil
+                        return PromisedReply<ServerMessage>(error: err)
                     })
             }
         }

--- a/TinodeSDK/Tinode.swift
+++ b/TinodeSDK/Tinode.swift
@@ -920,7 +920,7 @@ public class Tinode {
             let m = reconnecting ? "YES" : "NO"
             Tinode.log.info("Tinode connected: after reconnect - %@", m.description)
             let doLogin = tinode.autoLogin && tinode.loginCredentials != nil
-            let future = tinode.hello().then(onSuccess: { [weak self] pkt in
+            let future = tinode.hello().thenApply({ [weak self] pkt in
                 guard let self = self else {
                     throw TinodeError.invalidState("Missing Tinode instance in connection handler")
                 }
@@ -937,34 +937,28 @@ public class Tinode {
                     try self.resolveAllPromises(msg: pkt)
                 }
                 return nil
-            }, onFailure: { err in
-                Tinode.log.error("Connection error: %@", err.localizedDescription)
-                try self.rejectAllPromises(err: err)
-                return PromisedReply<ServerMessage>(error: err)
             })
             if doLogin {
-                future.then(
-                    onSuccess: { [weak self] msg in
-                        if let t = self?.tinode, let cred = t.loginCredentials, !t.loginInProgress {
-                            return t.login(
-                                scheme: cred.scheme, secret: cred.secret, creds: nil).then(
-                                    onSuccess: { msg in
-                                        try self?.resolveAllPromises(msg: msg)
-                                        return nil
-                                    },
-                                    onFailure: { err in
-                                        try self?.rejectAllPromises(err: err)
-                                        return PromisedReply<ServerMessage>(error: err)
-                                    })
-                        }
-                        return nil
-                    },
-                    onFailure: { [weak self] err in
-                        Tinode.log.error("Connection error: %@", err.localizedDescription)
-                        try self?.rejectAllPromises(err: err)
-                        return PromisedReply<ServerMessage>(error: err)
-                    })
+                future.thenApply({ [weak self] msg in
+                    if let t = self?.tinode, let cred = t.loginCredentials, !t.loginInProgress {
+                        return t.login(
+                            scheme: cred.scheme, secret: cred.secret, creds: nil).then(
+                                onSuccess: { msg in
+                                    try self?.resolveAllPromises(msg: msg)
+                                    return nil
+                                },
+                                onFailure: { err in
+                                    Tinode.log.error("Login error: %@", err.localizedDescription)
+                                    return PromisedReply<ServerMessage>(error: err)
+                                })
+                    }
+                    return nil
+                })
             }
+            future.thenCatch({ err in
+                Tinode.log.error("Connection error: %@", err.localizedDescription)
+                return PromisedReply<ServerMessage>(error: err)
+            })
         }
         func onMessage(with message: String) -> Void {
             Log.default.debug("in: %@", message)


### PR DESCRIPTION
* Login sequence `thenCatch` returned `nil` which was interpreted as the error was recovered from and caused the subsequent commands to be executed as if there was no error. Changed that to rejected promise. 
* There was a bunch of `rejectAllPromises` on failure which interfered with these promises being recovered in the step above + promise garbage collector on timer.
* There were two `thenCatch` in the same sequence with the same logic. I removed one.

There are a few `resolveAllPromises` in login sequence. They were copied from Android. I think they are no longer necessary. I'll remove them from android first and if it does not cause any problems then will remove from iOS.