### PR TITLE
<fix> blurred avatar while in personalsetting scene

### DIFF
--- a/Tinodios/AccountSettingsViewController.swift
+++ b/Tinodios/AccountSettingsViewController.swift
@@ -42,7 +42,7 @@ class AccountSettingsViewController: UITableViewController {
         self.userNameLabel.text = me.pub?.fn ?? NSLocalizedString("Unknown", comment: "Placeholder for missing user name")
 
         // Avatar.
-        self.avatarImageView.set(pub: me.pub, id: self.tinode.myUid, deleted: false)
+        self.avatarImageView.set(pub: me.pub, id: self.tinode.myUid, deleted: false, isAvatar: true)
         self.avatarImageView.letterTileFont = self.avatarImageView.letterTileFont.withSize(CGFloat(50))
 
         self.subtitleLabel.text = me.pub?.note ?? me.tags?.joined(separator: ", ")

--- a/Tinodios/CallViewController.swift
+++ b/Tinodios/CallViewController.swift
@@ -559,7 +559,7 @@ class CallViewController: UIViewController {
         if let topic = topic {
             peerNameLabel.text = topic.pub?.fn
             peerNameLabel.sizeToFit()
-            peerAvatarImageView.set(pub: topic.pub, id: topic.name, deleted: false)
+            peerAvatarImageView.set(pub: topic.pub, id: topic.name, deleted: false, isAvatar: true)
         }
     }
 

--- a/Tinodios/SettingsPersonalViewController.swift
+++ b/Tinodios/SettingsPersonalViewController.swift
@@ -78,7 +78,7 @@ class SettingsPersonalViewController: UITableViewController {
         }
 
         // Avatar.
-        self.avatarImage.set(pub: me.pub, id: self.tinode.myUid, deleted: false)
+        self.avatarImage.set(pub: me.pub, id: self.tinode.myUid, deleted: false, isAvatar: true)
         self.avatarImage.letterTileFont = self.avatarImage.letterTileFont.withSize(CGFloat(50))
         self.manageTags.detailTextLabel?.text = me.tags?.joined(separator: ", ")
 

--- a/Tinodios/TopicGeneralViewController.swift
+++ b/Tinodios/TopicGeneralViewController.swift
@@ -91,7 +91,7 @@ class TopicGeneralViewController: UITableViewController {
         topicPrivateLabel.textColor = topic?.comment?.isEmpty ?? true ? .placeholderText : .secondaryLabel
         topicPrivateLabel.text = (topic.comment ?? "").isEmpty ? NSLocalizedString("Private info: not set", comment: "Placeholder text in editor") : topic.comment
 
-        avatarImage.set(pub: topic.pub, id: topic.name, deleted: topic.deleted)
+        avatarImage.set(pub: topic.pub, id: topic.name, deleted: topic.deleted, isAvatar: true)
         avatarImage.letterTileFont = self.avatarImage.letterTileFont.withSize(CGFloat(50))
     }
 

--- a/Tinodios/TopicInfoViewController.swift
+++ b/Tinodios/TopicInfoViewController.swift
@@ -87,7 +87,7 @@ class TopicInfoViewController: UITableViewController {
         topicIDLabel.text = topic.name
         topicIDLabel.sizeToFit()
 
-        avatarImage.set(pub: topic.pub, id: topic.name, deleted: topic.deleted)
+        avatarImage.set(pub: topic.pub, id: topic.name, deleted: topic.deleted, isAvatar: true)
         avatarImage.letterTileFont = self.avatarImage.letterTileFont.withSize(CGFloat(50))
         mutedSwitch.isOn = topic.isMuted
         archivedSwitch.isOn = topic.isArchived

--- a/Tinodios/widgets/RoundImageView.swift
+++ b/Tinodios/widgets/RoundImageView.swift
@@ -99,7 +99,8 @@ public class RoundImageView: UIImageView {
         self.init(frame: .zero)
     }
 
-    public func set(pub: TheCard?, id: String?, deleted: Bool) {
+    public func set(pub: TheCard?, id: String?, deleted: Bool, isAvatar: Bool = false) {
+        var avatarImg = false
         if let ref = pub?.photo?.ref, let url = URL(string: ref, relativeTo: Cache.tinode.baseURL(useWebsocketProtocol: false)) {
             let modifier = AnyModifier { request in
                 var request = request
@@ -115,6 +116,11 @@ public class RoundImageView: UIImageView {
                 }
                 // Ignoring the error: just keep the placeholder image.
             })
+            
+            // custom define avatar
+            if isAvatar {
+                avatarImg = true
+            }
         }
 
         if let icon = pub?.photo?.image {
@@ -122,7 +128,9 @@ public class RoundImageView: UIImageView {
             self.backgroundColor = nil
             self.initials = nil
             // Avatar image provided.
-            self.image = deleted ? icon.noir : icon
+            if !avatarImg {
+                self.image = deleted ? icon.noir : icon
+            }
         } else {
             if let id = id, !id.isEmpty {
                 switch Tinode.topicTypeByName(name: id) {


### PR DESCRIPTION
I found my avatar is blurred if I use custom image for my avatar. And I found the problem is in RoundImageView.swift.

The image would be overrided by base64 data while icon set. I just added the function param: isAvatar . 
And it can differ from list icon and avatar.

It's useful for me.
